### PR TITLE
Support for evaluation using current context.

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ mobj = fn.create("transform")
 node = cmdx.Node(mobj)
 ```
 
-This will use the hash if a `cmdx` instance of this `MObject` already exist, else it will instantiate a new. The performance difference is slim and as such this is the recommended approach. The exception is if you happen to already has either an `MObjectHandle` or a corresponding `hashCode` at hand, in which case you can save a handful of cycles per call by using `fromHash` or `fromHex`. 
+This will use the hash if a `cmdx` instance of this `MObject` already exist, else it will instantiate a new. The performance difference is slim and as such this is the recommended approach. The exception is if you happen to already has either an `MObjectHandle` or a corresponding `hashCode` at hand, in which case you can save a handful of cycles per call by using `fromHash` or `fromHex`.
 
 <br>
 
@@ -481,7 +481,7 @@ TypeError: listConnections() got an unexpected keyword argument 'source'
 ```
 
 
-The reason for this limitation is because the functions `cmds` 
+The reason for this limitation is because the functions `cmds`
 
 - Submit an [issue](issues) or [pull-request](#fork) with commands you miss
 
@@ -603,20 +603,20 @@ cmdx.createNode(cmdx.tTransform)
 
 Only the most commonly used and performance sensitive types are available as explicit types.
 
-- `tAddDoubleLinear` 
-- `tAddMatrix` 
-- `tAngleBetween` 
-- `tMultMatrix` 
-- `tAngleDimension` 
-- `tBezierCurve` 
-- `tBlendShape` 
-- `tCamera` 
-- `tChoice` 
-- `tChooser` 
-- `tCondition` 
-- `tTransform` 
-- `tTransformGeometry` 
-- `tWtAddMatrix` 
+- `tAddDoubleLinear`
+- `tAddMatrix`
+- `tAngleBetween`
+- `tMultMatrix`
+- `tAngleDimension`
+- `tBezierCurve`
+- `tBlendShape`
+- `tCamera`
+- `tChoice`
+- `tChooser`
+- `tCondition`
+- `tTransform`
+- `tTransformGeometry`
+- `tWtAddMatrix`
 
 <br>
 
@@ -780,6 +780,20 @@ node = cmdx.createNode("transform")
 cmds.setKeyframe(str(node), attribute="tx", time=[1, 100], value=0.0)
 cmds.setKeyframe(str(node), attribute="tx", time=[50], value=10.0)
 cmds.keyTangent(str(node), attribute="tx", time=(1, 100), outTangentType="linear")
+node["tx"].read(time=50)
+# 10.0
+```
+
+In Maya 2018 and above, `Plug.read` will yield the result based on the current evaluation context. Following on from the above example.
+
+```python
+from maya.api import OpenMaya as om
+
+context = om.MDGContext(om.MTime(50, unit=om.MTime.uiUnit()))
+context.makeCurrent()
+node["tx"].read() # Evaluates the context at frame 50
+# 10.0
+om.MDGContext.kNormal.makeCurrent()
 ```
 
 <br>
@@ -1290,7 +1304,7 @@ a.children() == [b, c]
 False  # The iterator does not equal the list, no matter the content
 ```
 
-From a performance perspective, returning all values from an iterator is equally fast as returning them all at once, as `cmds` does, so you may wonder why do it this way? 
+From a performance perspective, returning all values from an iterator is equally fast as returning them all at once, as `cmds` does, so you may wonder why do it this way?
 
 It's because an iterator only spends time computing the values requested, so returning any number *less than* the total number yields performance benefits.
 
@@ -1462,7 +1476,7 @@ On creation, a node is "selected" which is leveraged by subsequent commands, com
 
 A scene description never faces naming or parenting problems the way programmers do. In a scene description, there is no need to rename nor reparent; a node is created either as a child of another, or not. It is given a name, which is unique. No ambiguity.
 
-From there, it was given expressions, functions, branching logic and was made into a scripting language where the standard library is a scene description kit. 
+From there, it was given expressions, functions, branching logic and was made into a scripting language where the standard library is a scene description kit.
 
 `cmds` is tedious and `pymel` is slow. `cmds` is also a victim of its own success. Like MEL, it works with relative paths and the current selection; this facilitates the compact file format, whereby a node is created, and then any references to this node is implicit in each subsequent line. Long attribute names have a short equivalent and paths need only be given at enough specificity to not be ambiguous given everything else that was previously created. Great for scene a file format, not so great for code that operates on-top of this scene file.
 
@@ -1811,7 +1825,7 @@ Additional thoughts.
 
 #### MDagModifier
 
-`createNode` of `OpenMaya.MDagModifier` is ~20% faster than `cmdx.createNode` *excluding* load. Including load is 5% *slower* than `cmdx`. 
+`createNode` of `OpenMaya.MDagModifier` is ~20% faster than `cmdx.createNode` *excluding* load. Including load is 5% *slower* than `cmdx`.
 
 ```python
 from maya.api import OpenMaya as om

--- a/cmdx.py
+++ b/cmdx.py
@@ -2506,14 +2506,12 @@ class Plug(object):
             ...   animcurve.keys(times=[1.0, 2.0], values=[0.0, 5.0])
             ...   node["tx"].read()
             ...   context = om.MDGContext(om.MTime(2.0, om.MTime.uiUnit()))
-            ...   context.makeCurrent()
+            ...   _ = context.makeCurrent()
             ...   node["tx"].read()
-            ...   om.MDGContext.kNormal.makeCurrent()
+            ...   _ = om.MDGContext.kNormal.makeCurrent()
             ...
             0.0
-             ...
             5.0
-             ...
 
         """
         unit = unit if unit is not None else self._unit

--- a/cmdx.py
+++ b/cmdx.py
@@ -2500,13 +2500,6 @@ class Plug(object):
             100.0
             >>> node["ty"].read(unit=Meters)
             1.0
-            >>> animcurve = createNode("animCurveTL")
-            >>> animcurve["output"] >> node["tx"]
-            >>> animcurve.keys(times=[1.0, 2.0], values=[0.0, 5.0])
-            >>> node["tx"].read()
-            0.0
-            >>> node["tx"].read(time=2.0)
-            5.0
 
         """
         unit = unit if unit is not None else self._unit

--- a/cmdx.py
+++ b/cmdx.py
@@ -2487,6 +2487,35 @@ class Plug(object):
         )
 
     def read(self, unit=None, time=None):
+        """Read attribute value
+
+        Arguments:
+            unit (int, optional): Unit with which to read plug
+            time (float, optional): Time at which to read plug
+
+        Example:
+            >>> node = createNode("transform")
+            >>> node["ty"] = 100.0
+            >>> node["ty"].read()
+            100.0
+            >>> node["ty"].read(unit=Meters)
+            1.0
+            >>> if hasattr(om.MDGContext, "makeCurrent"):
+            ...   animcurve = createNode("animCurveTL")
+            ...   animcurve["output"] >> node["tx"]
+            ...   animcurve.keys(times=[1.0, 2.0], values=[0.0, 5.0])
+            ...   node["tx"].read()
+            ...   context = om.MDGContext(om.MTime(2.0, om.MTime.uiUnit()))
+            ...   context.makeCurrent()
+            ...   node["tx"].read()
+            ...   om.MDGContext.kNormal.makeCurrent()
+            ...
+            0.0
+             ...
+            5.0
+             ...
+
+        """
         unit = unit if unit is not None else self._unit
         context = None
 

--- a/cmdx.py
+++ b/cmdx.py
@@ -16,7 +16,7 @@ from maya import cmds
 from maya.api import OpenMaya as om, OpenMayaAnim as oma, OpenMayaUI as omui
 from maya import OpenMaya as om1, OpenMayaMPx as ompx1, OpenMayaUI as omui1
 
-__version__ = "0.4.0"
+__version__ = "0.4.4"
 
 PY3 = sys.version_info[0] == 3
 

--- a/cmdx.py
+++ b/cmdx.py
@@ -2500,17 +2500,12 @@ class Plug(object):
             100.0
             >>> node["ty"].read(unit=Meters)
             1.0
-            >>> if hasattr(om.MDGContext, "makeCurrent"):
-            ...   animcurve = createNode("animCurveTL")
-            ...   animcurve["output"] >> node["tx"]
-            ...   animcurve.keys(times=[1.0, 2.0], values=[0.0, 5.0])
-            ...   node["tx"].read()
-            ...   context = om.MDGContext(om.MTime(2.0, om.MTime.uiUnit()))
-            ...   _ = context.makeCurrent()
-            ...   node["tx"].read()
-            ...   _ = om.MDGContext.kNormal.makeCurrent()
-            ...
+            >>> animcurve = createNode("animCurveTL")
+            >>> animcurve["output"] >> node["tx"]
+            >>> animcurve.keys(times=[1.0, 2.0], values=[0.0, 5.0])
+            >>> node["tx"].read()
             0.0
+            >>> node["tx"].read(time=2.0)
             5.0
 
         """

--- a/cmdx.py
+++ b/cmdx.py
@@ -2304,12 +2304,11 @@ class Plug(object):
 
         """
 
-        context = om.MDGContext.kNormal
-
         if time is not None:
             context = om.MDGContext(om.MTime(time, om.MTime.uiUnit()))
+            return om.MFnMatrixData(self._mplug.asMObject(context)).matrix()
 
-        return om.MFnMatrixData(self._mplug.asMObject(context)).matrix()
+        return om.MFnMatrixData(self._mplug.asMObject()).matrix()
 
     def asTransformationMatrix(self, time=None):
         """Return plug as TransformationMatrix
@@ -3039,8 +3038,10 @@ def _plug_to_python(plug, unit=None, context=None):
 
     assert not plug.isNull, "'%s' was null" % plug
 
-    if context is None:
-        context = om.MDGContext.kNormal
+    kwargs = dict()
+
+    if context is not None:
+        kwargs["context"] = context
 
     # Multi attributes
     #   _____
@@ -3097,14 +3098,14 @@ def _plug_to_python(plug, unit=None, context=None):
                 plug = plug.elementByLogicalIndex(0)
 
             return tuple(
-                om.MFnMatrixData(plug.asMObject(context)).matrix()
+                om.MFnMatrixData(plug.asMObject(**kwargs)).matrix()
             )
 
         elif innerType == om.MFnData.kString:
-            return plug.asString(context)
+            return plug.asString(**kwargs)
 
         elif innerType == om.MFnData.kNurbsCurve:
-            return om.MFnNurbsCurveData(plug.asMObject(context))
+            return om.MFnNurbsCurveData(plug.asMObject(**kwargs))
 
         elif innerType == om.MFnData.kComponentList:
             return None
@@ -3119,7 +3120,7 @@ def _plug_to_python(plug, unit=None, context=None):
             return None
 
     elif type == om.MFn.kMatrixAttribute:
-        return tuple(om.MFnMatrixData(plug.asMObject(context)).matrix())
+        return tuple(om.MFnMatrixData(plug.asMObject(**kwargs)).matrix())
 
     elif type == om.MFnData.kDoubleArray:
         raise TypeError("%s: kDoubleArray is not supported" % plug)
@@ -3128,38 +3129,38 @@ def _plug_to_python(plug, unit=None, context=None):
                   om.MFn.kFloatLinearAttribute):
 
         if unit is None:
-            return plug.asMDistance(context).asUnits(Centimeters)
+            return plug.asMDistance(**kwargs).asUnits(Centimeters)
         elif unit == Millimeters:
-            return plug.asMDistance(context).asMillimeters()
+            return plug.asMDistance(**kwargs).asMillimeters()
         elif unit == Centimeters:
-            return plug.asMDistance(context).asCentimeters()
+            return plug.asMDistance(**kwargs).asCentimeters()
         elif unit == Meters:
-            return plug.asMDistance(context).asMeters()
+            return plug.asMDistance(**kwargs).asMeters()
         elif unit == Kilometers:
-            return plug.asMDistance(context).asKilometers()
+            return plug.asMDistance(**kwargs).asKilometers()
         elif unit == Inches:
-            return plug.asMDistance(context).asInches()
+            return plug.asMDistance(**kwargs).asInches()
         elif unit == Feet:
-            return plug.asMDistance(context).asFeet()
+            return plug.asMDistance(**kwargs).asFeet()
         elif unit == Miles:
-            return plug.asMDistance(context).asMiles()
+            return plug.asMDistance(**kwargs).asMiles()
         elif unit == Yards:
-            return plug.asMDistance(context).asYards()
+            return plug.asMDistance(**kwargs).asYards()
         else:
             raise TypeError("Unsupported unit '%d'" % unit)
 
     elif type in (om.MFn.kDoubleAngleAttribute,
                   om.MFn.kFloatAngleAttribute):
         if unit is None:
-            return plug.asMAngle(context).asUnits(Radians)
+            return plug.asMAngle(**kwargs).asUnits(Radians)
         elif unit == Degrees:
-            return plug.asMAngle(context).asDegrees()
+            return plug.asMAngle(**kwargs).asDegrees()
         elif unit == Radians:
-            return plug.asMAngle(context).asRadians()
+            return plug.asMAngle(**kwargs).asRadians()
         elif unit == AngularSeconds:
-            return plug.asMAngle(context).asAngSeconds()
+            return plug.asMAngle(**kwargs).asAngSeconds()
         elif unit == AngularMinutes:
-            return plug.asMAngle(context).asAngMinutes()
+            return plug.asMAngle(**kwargs).asAngMinutes()
         else:
             raise TypeError("Unsupported unit '%d'" % unit)
 
@@ -3168,18 +3169,18 @@ def _plug_to_python(plug, unit=None, context=None):
         innerType = om.MFnNumericAttribute(attr).numericType()
 
         if innerType == om.MFnNumericData.kBoolean:
-            return plug.asBool(context)
+            return plug.asBool(**kwargs)
 
         elif innerType in (om.MFnNumericData.kShort,
                            om.MFnNumericData.kInt,
                            om.MFnNumericData.kLong,
                            om.MFnNumericData.kByte):
-            return plug.asInt(context)
+            return plug.asInt(**kwargs)
 
         elif innerType in (om.MFnNumericData.kFloat,
                            om.MFnNumericData.kDouble,
                            om.MFnNumericData.kAddr):
-            return plug.asDouble(context)
+            return plug.asDouble(**kwargs)
 
         else:
             raise TypeError("Unsupported numeric type: %s"
@@ -3187,14 +3188,14 @@ def _plug_to_python(plug, unit=None, context=None):
 
     # Enum
     elif type == om.MFn.kEnumAttribute:
-        return plug.asShort(context)
+        return plug.asShort(**kwargs)
 
     elif type == om.MFn.kMessageAttribute:
         # In order to comply with `if plug:`
         return True
 
     elif type == om.MFn.kTimeAttribute:
-        return plug.asShort(context)
+        return plug.asShort(**kwargs)
 
     elif type == om.MFn.kInvalid:
         raise TypeError("%s was invalid" % plug.name())

--- a/tests.py
+++ b/tests.py
@@ -149,6 +149,19 @@ def test_getattrtime():
     assert_almost_equals(transform["ty"].read(time=5), 5.0, places=5)
     assert_almost_equals(transform["ty"].read(time=10), 10.0, places=5)
 
+    # From the current context (Maya 2018 and above)
+    if hasattr(om.MDGContext, "makeCurrent"):
+        context = om.MDGContext(om.MTime(1.0, om.MTime.uiUnit()))
+        context.makeCurrent()
+        assert_almost_equals(transform["ty"].read(), 1.0, places=5)
+        context = om.MDGContext(om.MTime(5.0, om.MTime.uiUnit()))
+        context.makeCurrent()
+        assert_almost_equals(transform["ty"].read(), 5.0, places=5)
+        context = om.MDGContext(om.MTime(10.0, om.MTime.uiUnit()))
+        context.makeCurrent()
+        assert_almost_equals(transform["ty"].read(), 10.0, places=5)
+        om.MDGContext.kNormal.makeCurrent()
+
 
 def test_setattr():
     """Setting attributes works well"""


### PR DESCRIPTION
Support for the Maya 2018 and above feature of [evaluating the current context](https://help.autodesk.com/cloudhelp/2018/ENU/Maya-SDK/files-to-wrap/GUID-A88F1AEC-3B1F-45DC-91C1-61CCF5A7F51A.htm).

That help page explains it well, but it allows you to set contexts and then every time you're calling a command that accepts a context it will automatically evaluate the current context:

```python
context = om.MDGContext(om.MTime(50, unit=om.MTime.uiUnit()))
context.makeCurrent()
node["worldMatrix"][0].asMatrix() # evaluates the context at frame 50
om.MDGContext.kNormal.makeCurrent()
```
Of course that's a silly example where you could just call `node["worldMatrix"][0].asMatrix(50)`. The part where it gets nice is if you wrap that in a context manager and you're querying a bunch of nodes, it helps keep your code clean and avoids the creation of the same context over and over:

```python
with Context(50):
    node1["worldMatrix"][0].asMatrix()
    node2["worldMatrix"][0].asMatrix()
    node3["worldMatrix"][0].asMatrix()
```