### PR TITLE
Improved Python 3 support

### DIFF
--- a/cmdx.py
+++ b/cmdx.py
@@ -16,7 +16,7 @@ from maya import cmds
 from maya.api import OpenMaya as om, OpenMayaAnim as oma, OpenMayaUI as omui
 from maya import OpenMaya as om1, OpenMayaMPx as ompx1, OpenMayaUI as omui1
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 PY3 = sys.version_info[0] == 3
 


### PR DESCRIPTION
Metaclasses has changed in Python 3 (i.e. Maya 2021+), this bridges the gap between the two. Before, one of the noticeable effects was that specialised objects, like Object Sets, wouldn't be assigned their appropriate ObjectSet subclass. But it's also used in node reuse, so memory would have suffered and references would not have worked.