### PR TITLE
Add support for writing to a matrix plug

### DIFF
--- a/README.md
+++ b/README.md
@@ -832,6 +832,28 @@ node["myArray"][2]
 
 <br>
 
+### Matrix Attributes
+
+Create and edit matrix attributes like any other attribute.
+
+For example, here's how you can store a copy of the current worldmatrix of any given node.
+
+```py
+import cmdx
+
+node = cmdx.createNode("transform")
+node["translate"] = (1, 2, 3)
+node["rotate", cmdx.Degrees] = (20, 30, 40)
+
+# Create a new matrix attribute
+node["myMatrix"] = cmdx.Matrix()
+
+# Store current world matrix in this custom attribute
+node["myMatrix"] = node["worldMatrix"][0].asMatrix()
+```
+
+<br>
+
 ### Native Types
 
 Maya boasts a library of classes that provide mathematical convenience functionality, such as rotating a vector, multiplying matrices or converting between Euler degrees and Quaternions.

--- a/cmdx.py
+++ b/cmdx.py
@@ -16,7 +16,7 @@ from maya import cmds
 from maya.api import OpenMaya as om, OpenMayaAnim as oma, OpenMayaUI as omui
 from maya import OpenMaya as om1, OpenMayaMPx as ompx1, OpenMayaUI as omui1
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 PY3 = sys.version_info[0] == 3
 
@@ -3283,6 +3283,11 @@ def _python_to_plug(value, plug):
     elif isinstance(value, om.MPoint):
         for index, value in enumerate(value):
             _python_to_plug(value, plug[index])
+
+    elif isinstance(value, om.MMatrix):
+        matrixData = om.MFnMatrixData()
+        matobj = matrixData.create(value)
+        plug._mplug.setMObject(matobj)
 
     elif plug._mplug.isCompound:
         count = plug._mplug.numChildren()


### PR DESCRIPTION
Now you can both create and edit a matrix attribute via cmdx.

```py
node = cmdx.createNode("transform")
node["translate"] = (1, 2, 3)
node["rotate", cmdx.Degrees] = (20, 30, 40)

# Create a new matrix attribute
node["myMatrix"] = cmdx.Matrix()

# Store current world matrix in this custom attribute
node["myMatrix"] = node["worldMatrix"][0].asMatrix()
```