### PR TITLE
Usability

### DIFF
--- a/cmdx.py
+++ b/cmdx.py
@@ -2154,9 +2154,6 @@ class Plug(object):
 
         """
 
-        # Rescue the user from certain crash
-        assert index >= 0, "Logical indexes cannot be negative"
-
         cls = self.__class__
 
         if isinstance(index, int):
@@ -2945,15 +2942,17 @@ class MatrixType(om.MMatrix):
 
         """
 
-        if isinstance(item, tuple):
-            assert len(item) == 2, (
-                "Must provide either 1 or 2 coordinates, "
-                "for row and element respectively"
-            )
+        if len(item) == 1:
+            return self.row(*item)
+
+        elif len(item) == 2:
             return self.element(*item)
 
         else:
-            return self.row(item)
+            raise ValueError(
+                "Must provide either 1 or 2 coordinates, "
+                "for row and element respectively"
+            )
 
     def __mul__(self, other):
         return type(self)(super(MatrixType, self).__mul__(other))

--- a/cmdx.py
+++ b/cmdx.py
@@ -16,7 +16,7 @@ from maya import cmds
 from maya.api import OpenMaya as om, OpenMayaAnim as oma, OpenMayaUI as omui
 from maya import OpenMaya as om1, OpenMayaMPx as ompx1, OpenMayaUI as omui1
 
-__version__ = "0.4.5"
+__version__ = "0.4.6"
 
 PY3 = sys.version_info[0] == 3
 

--- a/cmdx.py
+++ b/cmdx.py
@@ -1207,6 +1207,11 @@ class DagNode(Node):
 
         return self.path().count("|") - 1
 
+    @property
+    def boundingBox(self):
+        """Return a cmdx.BoundingBox of this DAG node"""
+        return BoundingBox(self._fn.boundingBox)
+
     def hide(self):
         """Set visibility to False"""
         self["visibility"] = False
@@ -1630,6 +1635,7 @@ class DagNode(Node):
         limit_value = limitValue
         set_limit = setLimit
         enable_limit = enableLimit
+        bounding_box = boundingBox
 
 
 # MFnTransform Limit Types
@@ -3024,6 +3030,9 @@ class Point(om.MPoint):
 
 class BoundingBox(om.MBoundingBox):
     """Maya's MBoundingBox"""
+
+    def volume(self):
+        return self.width * self.height * self.depth
 
 
 class Quaternion(om.MQuaternion):


### PR DESCRIPTION
A bunch of usability improvements.

- Removed unused `NODE_REUSE` and `PLUG_REUSE` environment variables, these were initially proof-of-concept but it's safe to say they were a success and now a fundamental part of cmdx.
- Added `Seconds`, `Milliseconds`, `Minutes` and `UiUnit()` as units for plug reading. `UiUnits` being a function, since the actual value changes when the user edits Maya's global preferences
- Improved `cmdx.Divider` to actually let you control the attribute name (used to be automatic and clever)
- [Added `plug.writable`](#writable) for a convenient way of spotting whether you can actually write to a plug
- Added `plug.default` to fetch a plug's default value, taking attribute type into account. Similar to `cmds.attributeQuery(listDefault=True)`
- Added ability to write a 16-tuple as a matrix (rather than having to manually cast it to a `MMatrix`
- [Added `Node.reset()`](#reset) and `DGModifier.resetAttr()` to reset an attribute to its default value
- Added `MatrixType` to handle indexing and future more-granular index manipulation.
- Fixed `node["myTimeAttr"].read()` such that it returns a float rather than an int
   - NOTE: There is a still a discrepancy between what is read and written; read returns a value in the current UI-unit, whereas write takes a value in *Seconds*. Writing currently doesn't massage the values you put into it so it's a little harder to control at the moment. The same is true for reading of degrees, which takes radians as input. Luckily, both API and UI defaults to centimeters for distance-type attributes.
- Added `cmdx.DagNode.boundingBox` and `BoundingBox.volume()` for computing the volume of any DagNode (approximate, based on whatever bounding box information Maya has already got about your object)

### writable

```py
# Before
if not node["tx"].connected and not node["tx"].locked:
  node["tx"] = 5

# After
if node["tx]".writable:
  node["tx"] = 5
```

### reset

A much simplified manner in which to reset an attribute to whatever value was its default.

```py
# Before
plug = node["myAttr"]._mplug
attr = plug.attribute()
type = attr.apiType()
assert type == om.MFn.kNumericAttribute
default = om.MFnNumericAttribute(attr).default
node["myAttr"] = default

# After
node["myAttr"].reset()
```

Also works with undo.

```py
with cmdx.DGModifier() as mod:
   mod.resetAttr(node["myAttr"])
```