### PR TITLE
Automatically convert from string -> cmdx for convenience functions

### DIFF
--- a/cmdx.py
+++ b/cmdx.py
@@ -993,7 +993,7 @@ class Node(object):
 
         if isinstance(attr, str):
             node, attr = attr.rsplit(".", 1)
-            node = cmdx.encode(node)
+            node = encode(node)
             attr = node[attr]
 
         if isinstance(attr, _AbstractAttribute):
@@ -4176,7 +4176,7 @@ def setAttr(attr, value, type=None):
 
     if isinstance(attr, str):
         node, attr = attr.rsplit(".", 1)
-        node = cmdx.encode(node)
+        node = encode(node)
         attr = node[attr]
 
     attr.write(value)
@@ -4315,23 +4315,27 @@ def connectAttr(src, dst):
 
     """
 
-    if isinstance(attr, str):
-        node, attr = attr.rsplit(".", 1)
-        node = cmdx.encode(node)
-        attr = node[attr]
+    if isinstance(src, str):
+        node, src = src.rsplit(".", 1)
+        node = encode(node)
+        src = node[src]
+
+    if isinstance(dst, str):
+        node, dst = dst.rsplit(".", 1)
+        node = encode(node)
+        dst = node[dst]
 
     src.connect(dst)
 
 
 def delete(*nodes):
-    
-    if isinstance(attr, str):
-        node, attr = attr.rsplit(".", 1)
-        node = cmdx.encode(node)
-        attr = node[attr]
 
     with DGModifier() as mod:
         for node in nodes:
+            if isinstance(node, str):
+                node, node = node.rsplit(".", 1)
+                node = encode(node)
+                node = node[node]
             mod.delete(node)
 
 

--- a/cmdx.py
+++ b/cmdx.py
@@ -991,6 +991,11 @@ class Node(object):
 
         """
 
+        if isinstance(attr, str):
+            node, attr = attr.rsplit(".", 1)
+            node = cmdx.encode(node)
+            attr = node[attr]
+
         if isinstance(attr, _AbstractAttribute):
             attr = attr.create()
 
@@ -4169,6 +4174,11 @@ def setAttr(attr, value, type=None):
 
     """
 
+    if isinstance(attr, str):
+        node, attr = attr.rsplit(".", 1)
+        node = cmdx.encode(node)
+        attr = node[attr]
+
     attr.write(value)
 
 
@@ -4243,8 +4253,8 @@ def listRelatives(node,
         >>> parent = createNode("transform")
         >>> child = createNode("transform", parent=parent)
         >>> listRelatives(child, parent=True) == [parent]
-        >>> listRelatives(str(child), parent=True) == [str(parent)]
         True
+        >>> listRelatives(str(child), parent=True) == [str(parent)]
         True
 
     """
@@ -4257,7 +4267,6 @@ def listRelatives(node,
 
     elif allDescendents:
         return list(node.descendents(type=type))
-
     elif shapes:
         return list(node.shapes(type=type))
 
@@ -4306,10 +4315,21 @@ def connectAttr(src, dst):
 
     """
 
+    if isinstance(attr, str):
+        node, attr = attr.rsplit(".", 1)
+        node = cmdx.encode(node)
+        attr = node[attr]
+
     src.connect(dst)
 
 
 def delete(*nodes):
+    
+    if isinstance(attr, str):
+        node, attr = attr.rsplit(".", 1)
+        node = cmdx.encode(node)
+        attr = node[attr]
+
     with DGModifier() as mod:
         for node in nodes:
             mod.delete(node)

--- a/cmdx.py
+++ b/cmdx.py
@@ -4250,6 +4250,9 @@ def listRelatives(node,
     if not isinstance(node, DagNode):
         return None
 
+    if isinstance(node, str):
+        node = encode(node)
+
     elif allDescendents:
         return list(node.descendents(type=type))
 

--- a/cmdx.py
+++ b/cmdx.py
@@ -4247,11 +4247,11 @@ def listRelatives(node,
 
     """
 
-    if not isinstance(node, DagNode):
-        return None
-
     if isinstance(node, str):
         node = encode(node)
+
+    if not isinstance(node, DagNode):
+        return None
 
     elif allDescendents:
         return list(node.descendents(type=type))

--- a/cmdx.py
+++ b/cmdx.py
@@ -4243,6 +4243,8 @@ def listRelatives(node,
         >>> parent = createNode("transform")
         >>> child = createNode("transform", parent=parent)
         >>> listRelatives(child, parent=True) == [parent]
+        >>> listRelatives(str(child), parent=True) == [str(parent)]
+        True
         True
 
     """


### PR DESCRIPTION
Added 
`if isinstance(node, str):`
    `node = encode(node)`
to listRelatives so it behaves more like the cmds command.