### PR TITLE
Usability

### DIFF
--- a/cmdx.py
+++ b/cmdx.py
@@ -3247,7 +3247,7 @@ def _plug_to_python(plug, unit=None, context=None):
         6
         >>> "%.3f" % time["outTime"]  # Seconds
         '0.042'
-        >>> "%.2f" % time["outTime", UiUnit()]
+        >>> "%.1f" % time["outTime", UiUnit()]
         '1.0'
 
     """

--- a/cmdx.py
+++ b/cmdx.py
@@ -3399,10 +3399,10 @@ def _plug_to_python(plug, unit=None, context=None):
         return True
 
     elif type == om.MFn.kTimeAttribute:
-        if unit:
-            return plug.asMTime(**kwargs).asUnits(unit)
-        else:
-            return plug.asMTime(**kwargs).value
+        # MTime.value returns in UI units, which is inconsistent
+        # with e.g. angular and linear attributes, which both return
+        # UI-independent units.
+        return plug.asMTime(**kwargs).asUnits(unit or Seconds)
 
     elif type == om.MFn.kInvalid:
         raise TypeError("%s was invalid" % plug.name())

--- a/cmdx.py
+++ b/cmdx.py
@@ -3241,13 +3241,14 @@ def _plug_to_python(plug, unit=None, context=None):
     Examples:
         >>> from maya import cmds
         >>> cmds.currentTime(1)
+        1.0
         >>> time = encode("time1")
         >>> UiUnits()  # 24 fps
         6
         >>> "%.3f" % time["outTime"]  # Seconds
-        0.042
-        >>> "%.2f" % time["outTime", UiUnits()]
-        1.0
+        '0.042'
+        >>> "%.2f" % time["outTime", UiUnit()]
+        '1.0'
 
     """
 

--- a/cmdx.py
+++ b/cmdx.py
@@ -3243,7 +3243,7 @@ def _plug_to_python(plug, unit=None, context=None):
         >>> cmds.currentTime(1)
         1.0
         >>> time = encode("time1")
-        >>> UiUnits()  # 24 fps
+        >>> UiUnit()  # 24 fps
         6
         >>> "%.3f" % time["outTime"]  # Seconds
         '0.042'

--- a/cmdx.py
+++ b/cmdx.py
@@ -3238,6 +3238,17 @@ def _plug_to_python(plug, unit=None, context=None):
         unit (int, optional): Return value in this unit, e.g. Meters
         context (om.MDGContext, optional): Return value in this context
 
+    Examples:
+        >>> from maya import cmds
+        >>> cmds.currentTime(1)
+        >>> time = encode("time1")
+        >>> UiUnits()  # 24 fps
+        6
+        >>> "%.3f" % time["outTime"]  # Seconds
+        0.042
+        >>> "%.2f" % time["outTime", UiUnits()]
+        1.0
+
     """
 
     assert not plug.isNull, "'%s' was null" % plug


### PR DESCRIPTION
Minor usability improvements.

- `cmdx.Plug.append(autofill)` for when you want to append to the next available index, rather than the largest index. That is, if an index is connected and then disconnected, the default index would be `1` even though `0` is available. Autofill attempts to utilise indices that are free by searching for the first unconnected index in an array attribute.
- Time plugs, e.g. `cmdx.encode("time1")["outTime"]`, now returns a value in `cmdx.Seconds`, which is consistent with how values are written to it, and to how they are written with the Maya Python API 2.0