### PR TITLE
DGContext uses Seconds by default, added UiUnits for each unit type

### DIFF
--- a/cmdx.py
+++ b/cmdx.py
@@ -4116,7 +4116,7 @@ class DagModifier(_BaseModifier):
 
 class DGContext(om.MDGContext):
 
-    def __init__(self, time=None):
+    def __init__(self, time=None, unit=None):
         """Context for evaluating the Maya DG
 
         Extension of MDGContext to also accept time as a float. In Maya 2018
@@ -4128,8 +4128,9 @@ class DGContext(om.MDGContext):
         """
 
         if time is not None:
-            if isinstance(time, (int, float)):
-                time = Seconds(time)
+            if not isinstance(time, TimeType):
+                unit = unit or Seconds
+                time = unit(time)
             super(DGContext, self).__init__(time)
         else:
             super(DGContext, self).__init__()

--- a/cmdx.py
+++ b/cmdx.py
@@ -16,7 +16,7 @@ from maya import cmds
 from maya.api import OpenMaya as om, OpenMayaAnim as oma, OpenMayaUI as omui
 from maya import OpenMaya as om1, OpenMayaMPx as ompx1, OpenMayaUI as omui1
 
-__version__ = "0.4.6"
+__version__ = "0.4.7"
 
 PY3 = sys.version_info[0] == 3
 

--- a/cmdx.py
+++ b/cmdx.py
@@ -298,6 +298,10 @@ def TimeUiUnit():
     return _Unit(om.MTime, om.MTime.uiUnit())
 
 
+# Alias
+UiUnit = TimeUiUnit
+
+
 _Cached = type("Cached", (object,), {})  # For isinstance(x, _Cached)
 Cached = _Cached()
 

--- a/cmdx.py
+++ b/cmdx.py
@@ -86,8 +86,6 @@ if not hasattr(om, "MObjectHandle"):
     log.warning("Node reuse might not work in this version of Maya "
                 "(OpenMaya.MObjectHandle not found)")
 
-TimeUnit = om.MTime.uiUnit()
-
 # DEPRECATED
 MTime = om.MTime
 MDistance = om.MDistance
@@ -267,6 +265,12 @@ Radians = _Unit(om.MAngle, om.MAngle.kRadians)
 AngularMinutes = _Unit(om.MAngle, om.MAngle.kAngMinutes)
 AngularSeconds = _Unit(om.MAngle, om.MAngle.kAngSeconds)
 
+
+def AngleUiUnit():
+    """Unlike other angle units, this can be modified by the user at run-time"""
+    return _Unit(om.MAngle, om.MAngle.uiUnit())
+
+
 # Distance units
 Millimeters = _Unit(om.MDistance, om.MDistance.kMillimeters)
 Centimeters = _Unit(om.MDistance, om.MDistance.kCentimeters)
@@ -277,13 +281,19 @@ Feet = _Unit(om.MDistance, om.MDistance.kFeet)
 Miles = _Unit(om.MDistance, om.MDistance.kMiles)
 Yards = _Unit(om.MDistance, om.MDistance.kYards)
 
+
+def DistanceUiUnit():
+    """Unlike other distance units, this can be modified by the user at run-time"""
+    return _Unit(om.MDistance, om.MDistance.uiUnit())
+
+
 # Time units
 Milliseconds = _Unit(om.MTime, om.MTime.kMilliseconds)
 Minutes = _Unit(om.MTime, om.MTime.kMinutes)
 Seconds = _Unit(om.MTime, om.MTime.kSeconds)
 
 
-def UiUnit():
+def TimeUiUnit():
     """Unlike other time units, this can be modified by the user at run-time"""
     return _Unit(om.MTime, om.MTime.uiUnit())
 
@@ -1827,7 +1837,7 @@ class AnimCurve(Node):
             self._fna = oma.MFnAnimCurve(mobj)
 
         def key(self, time, value, interpolation=Linear):
-            time = om.MTime(time, om.MTime.uiUnit())
+            time = Seconds(time)
             index = self._fna.find(time)
 
             if index:
@@ -1836,7 +1846,7 @@ class AnimCurve(Node):
                 self._fna.addKey(time, value, interpolation, interpolation)
 
         def keys(self, times, values, interpolation=Linear):
-            times = map(lambda t: om.MTime(t, TimeUnit), times)
+            times = map(lambda t: Seconds(t), times)
 
             try:
                 self._fna.addKeys(times, values)
@@ -3245,11 +3255,11 @@ def _plug_to_python(plug, unit=None, context=None):
         >>> cmds.currentTime(1)
         1.0
         >>> time = encode("time1")
-        >>> UiUnit()  # 24 fps
+        >>> TimeUiUnit()  # 24 fps
         6
         >>> "%.3f" % time["outTime"]  # Seconds
         '0.042'
-        >>> "%.1f" % time["outTime", UiUnit()]
+        >>> "%.1f" % time["outTime", TimeUiUnit()]
         '1.0'
 
     """
@@ -4119,7 +4129,7 @@ class DGContext(om.MDGContext):
 
         if time is not None:
             if isinstance(time, (int, float)):
-                time = om.MTime(time, om.MTime.uiUnit())
+                time = Seconds(time)
             super(DGContext, self).__init__(time)
         else:
             super(DGContext, self).__init__()

--- a/tests.py
+++ b/tests.py
@@ -157,6 +157,20 @@ def test_getattrtime():
             assert_almost_equals(transform["ty"].read(), 5.0, places=5)
         with cmdx.DGContext(1):
             assert_almost_equals(transform["ty"].read(), 10.0, places=5)
+        # Custom units
+        with cmdx.DGContext(0, cmdx.TimeUiUnit()):
+            assert_almost_equals(transform["ty"].read(), 0.0, places=5)
+        with cmdx.DGContext(12, cmdx.TimeUiUnit()):
+            assert_almost_equals(transform["ty"].read(), 5.0, places=5)
+        with cmdx.DGContext(24, cmdx.TimeUiUnit()):
+            assert_almost_equals(transform["ty"].read(), 10.0, places=5)
+        # Alternate syntax
+        with cmdx.DGContext(cmdx.TimeUiUnit()(0)):
+            assert_almost_equals(transform["ty"].read(), 0.0, places=5)
+        with cmdx.DGContext(cmdx.TimeUiUnit()(12)):
+            assert_almost_equals(transform["ty"].read(), 5.0, places=5)
+        with cmdx.DGContext(cmdx.TimeUiUnit()(24)):
+            assert_almost_equals(transform["ty"].read(), 10.0, places=5)
 
 
 def test_setattr():

--- a/tests.py
+++ b/tests.py
@@ -132,30 +132,30 @@ def test_getattrtime():
     """getAttr(time=)"""
     transform = cmdx.createNode("transform")
 
-    for time, value in ((1, 1.0),
-                        (10, 10.0)):
+    for time, value in ((0, 0.0),
+                        (24, 10.0)):
         cmds.setKeyframe(str(transform),
                          time=[time],
                          attribute="translateY",
                          value=value)
     cmds.keyTangent(str(transform),
                     edit=True,
-                    time=(1, 10),
+                    time=(0, 24),
                     attribute="translateY",
                     outTangentType="linear")
 
     # These floating point values can differ ever so slightly
-    assert_almost_equals(transform["ty"].read(time=1), 1.0, places=5)
-    assert_almost_equals(transform["ty"].read(time=5), 5.0, places=5)
-    assert_almost_equals(transform["ty"].read(time=10), 10.0, places=5)
+    assert_almost_equals(transform["ty"].read(time=0), 0.0, places=5)
+    assert_almost_equals(transform["ty"].read(time=0.5), 5.0, places=5)
+    assert_almost_equals(transform["ty"].read(time=1), 10.0, places=5)
 
     # From the current context (Maya 2018 and above)
     if hasattr(om.MDGContext, "makeCurrent"):
-        with cmdx.DGContext(1.0):
-            assert_almost_equals(transform["ty"].read(), 1.0, places=5)
-        with cmdx.DGContext(5.0):
+        with cmdx.DGContext(0):
+            assert_almost_equals(transform["ty"].read(), 0.0, places=5)
+        with cmdx.DGContext(0.5):
             assert_almost_equals(transform["ty"].read(), 5.0, places=5)
-        with cmdx.DGContext(10.0):
+        with cmdx.DGContext(1):
             assert_almost_equals(transform["ty"].read(), 10.0, places=5)
 
 


### PR DESCRIPTION
- Added `AngleUiUnit()` and `DistanceUiUnit()`
- Renamed `UiUnit()` to `TimeUiUnit()` for consistency
- `DGContext` now uses seconds by default
- `DGContext` supports a unit argument for different time units
```python
with cmdx.DGContext(1, cmdx.Minutes):
    pass
# Or
with cmdx.DGContext(cmdx.Minutes(1)):
    pass
```