### PR TITLE
Undo Caveat

### DIFF
--- a/docs/_sources/index.rst.txt
+++ b/docs/_sources/index.rst.txt
@@ -112,3 +112,4 @@ Interoperability
 
 .. autofunction:: encode
 .. autofunction:: decode
+.. autofunction:: commit


### PR DESCRIPTION
Minor addition to the README about the use of Undo, modifiers and `cmdx.commit`. This just bit me.