### PR TITLE
Change default unit for Angle attribute from Degrees to Radians

### DIFF
--- a/cmdx.py
+++ b/cmdx.py
@@ -5224,9 +5224,9 @@ class Angle(AbstractUnit):
     def default(self, cls=None):
         default = super(Angle, self).default(cls)
 
-        # When no unit was explicitly passed, assume degrees
+        # When no unit was explicitly passed, assume radians
         if not isinstance(default, om.MAngle):
-            default = om.MAngle(default, om.MAngle.kDegrees)
+            default = om.MAngle(default, om.MAngle.kRadians)
 
         return default
 


### PR DESCRIPTION
To align with the default unit throughout the rest of the code.

```py
node = cmdx.createNode("transform")
node["newAngle"] = cmdx.Angle(default=1)  # Radians, used to assume degrees
node["newAngle2"] = cmdx.Angle(default=cmdx.radians(45))
```