### PR TITLE
Node/DagNode: str constructor

### DIFF
--- a/cmdx.py
+++ b/cmdx.py
@@ -338,7 +338,11 @@ class Singleton(type):
     _instances = {}
 
     @withTiming()
-    def __call__(cls, mobject, exists=True, modifier=None):
+    def __call__(cls, mobject, exists=True, modifier=None):  # type: (Type, Union[om.MObject, str], bool, bool) -> Node
+        # string constructor -> use encode()
+        if isinstance(mobject, string_types):
+            return encode(mobject)
+
         handle = om.MObjectHandle(mobject)
         hsh = handle.hashCode()
         hx = "%x" % hsh


### PR DESCRIPTION
- allows `cmdx.Node(node_path)` syntax as an alternative to `cmdx.encode(node_path)`