### PR TITLE
Tweaks

### DIFF
--- a/cmdx.py
+++ b/cmdx.py
@@ -4428,6 +4428,12 @@ class DagModifier(_BaseModifier):
         create_node = createNode
 
 
+# Convenience functions
+def connect(a, b):
+    with DagModifier() as mod:
+        mod.connect(a, b)
+
+
 class DGContext(om.MDGContext):
 
     def __init__(self, time=None, unit=None):

--- a/cmdx.py
+++ b/cmdx.py
@@ -3861,6 +3861,18 @@ def _python_to_mod(value, plug, mod):
     return True
 
 
+def exists(path):
+    """Return whether any node at `path` exists"""
+
+    selectionList = om.MSelectionList()
+
+    try:
+        selectionList.add(path)
+    except RuntimeError:
+        return False
+    return True
+
+
 def encode(path):
     """Convert relative or absolute `path` to cmdx Node
 

--- a/cmdx.py
+++ b/cmdx.py
@@ -4162,6 +4162,11 @@ class _BaseModifier(object):
                 self.undoIt()
 
             raise ModifierError(self._history)
+        else:
+
+            # Facilitate multiple calls to doIt, whereby only
+            # the latest, actually-performed actions are reported
+            self._history[:] = []
 
         self.isDone = True
 

--- a/cmdx.py
+++ b/cmdx.py
@@ -1332,6 +1332,19 @@ class DagNode(Node):
         """Set visibility to True"""
         self["visibility"] = True
 
+    def childCount(self, type=None):
+        """Return number of children of a given optional type
+
+        Compared to `MFnDagNode.childCount`, this function actually returns
+        children, not shapes, along with filtering by an optional type.
+
+        Arguments:
+            type (str): Same as to .children(type=)
+
+        """
+
+        return len(list(self.children(type=type)))
+
     def addChild(self, child, index=Last, safe=True):
         """Add `child` to self
 
@@ -1744,6 +1757,7 @@ class DagNode(Node):
     if ENABLE_PEP8:
         shortest_path = shortestPath
         add_child = addChild
+        child_count = childCount
         dag_path = dagPath
         map_from = mapFrom
         map_to = mapTo


### PR DESCRIPTION
A few handy updates I find myself needing.

- `cmdx.exists` to quickly query existence
- `cmdx.DagModifier` improvied debugging
- `cmdx.connect` convenience function

<br>

```py
if cmdx.exists(someNode):
  say_hello()

if someNode.childCount() > 1:
  print("This joint has multiple children, yo")
```

This one is useful for debugging.

```py
with cmdx.DagModifier() as mod:
   tm = mod.create_node("transform")
   mod.doIt()
   mod.connect(tm["translateX"], tm["message"])
```

**Before**

```bash
# I had issues with `create_node` and `connect`
```

**After**

```bash
# I had issues with `connect`
```

Since we've already successfully done the prior with an explicit call to `doIt`. This helps when there's tons of things being done, but most of which have already been `doIt`.

And finally.

```py
cmdx.connect(a["plug1"], b["plug1"])
```

As a convenience function for..

```py
with cmdx.DagModifier() as mod:
  mod.connect(a["plug1"], b["plug2"])
```

To help with readability when most of the commands don't need/use a modifier, but just this one `connect` does.