### PR TITLE
Fix #47

### DIFF
--- a/cmdx.py
+++ b/cmdx.py
@@ -850,7 +850,7 @@ class Node(object):
             >>> plug1 = node.findPlug("translateX")
             >>> isinstance(plug1, om.MPlug)
             True
-            >>> plug1 is node.findPlug("translateX")
+            >>> plug1 is node.findPlug("translateX", safe=False)
             True
             >>> plug1 is node.findPlug("translateX", cached=True)
             True

--- a/cmdx.py
+++ b/cmdx.py
@@ -811,7 +811,7 @@ class Node(object):
 
     # Module-level branch; evaluated on import
     @withTiming("findPlug() reuse {time:.4f} ns")
-    def findPlug(self, name, cached=False):
+    def findPlug(self, name, cached=False, safe=True):
         """Cache previously found plugs, for performance
 
         Cost: 4.9 microseconds/call
@@ -837,7 +837,7 @@ class Node(object):
                 means it will run Maya's findPlug() and cache
                 the result.
             safe (bool, optional): Always find the plug through
-                Maya's API, defaults to False. This will not perform
+                Maya's API, defaults to True. This will not perform
                 any caching and is intended for use during debugging
                 to spot whether caching is causing trouble.
 
@@ -857,13 +857,17 @@ class Node(object):
 
         """
 
-        try:
-            existing = self._state["plugs"][name]
-            Stats.PlugReuseCount += 1
-            return existing
-        except KeyError:
-            if cached:
-                raise KeyError("'%s' not cached" % name)
+        if cached or not safe:
+            try:
+                existing = self._state["plugs"][name]
+                Stats.PlugReuseCount += 1
+                return existing
+
+            except KeyError:
+                # The user explicitly asked for a cached attribute,
+                # if this is not the case we must tell them about it
+                if cached:
+                    raise KeyError("'%s' not cached" % name)
 
         plug = self._fn.findPlug(name, False)
         self._state["plugs"][name] = plug
@@ -2535,7 +2539,7 @@ class Plug(object):
         else:
             obj = self._mplug.asMObject()
 
-        return om.MFnMatrixData(obj).matrix()
+        return MatrixType(om.MFnMatrixData(obj).matrix())
 
     def asTransformationMatrix(self, time=None):
         """Return plug as TransformationMatrix
@@ -3222,10 +3226,10 @@ class TransformationMatrix(om.MTransformationMatrix):
 
         return super(TransformationMatrix, self).setRotation(rot)
 
-    def asMatrix(self):  # type: () -> om.MMatrix
+    def asMatrix(self):  # type: () -> MatrixType
         return MatrixType(super(TransformationMatrix, self).asMatrix())
 
-    def asMatrixInverse(self):  # type: () -> om.MMatrix
+    def asMatrixInverse(self):  # type: () -> MatrixType
         return MatrixType(super(TransformationMatrix, self).asMatrixInverse())
 
     # A more intuitive alternative
@@ -3448,7 +3452,7 @@ class EulerRotation(om.MEulerRotation):
         return super(EulerRotation, self).asQuaternion()
 
     def asMatrix(self):
-        return super(EulerRotation, self).asMatrix()
+        return MatrixType(super(EulerRotation, self).asMatrix())
 
     order = {
         'xyz': kXYZ,


### PR DESCRIPTION
That is, disable plug reuse until we figure something better out. Stable > Fast.

The problem being that we're caching plugs by name. But when attributes are removed and re-added, the name is the same but attribute is different. So when we read and connect, we're doing that against an out-of-date attribute. Ideally we'd store a hash or `id()` of the attribute instead. But how can we know whether the plug we have is "valid"? The MObject has a `isValid()` so we can check and see whether the handle we've got is usable. MPlug has `isNull` which doesn't tell you whether the plug is valid or not. What else is there?