### PR TITLE
Animate

### DIFF
--- a/README.md
+++ b/README.md
@@ -849,6 +849,41 @@ assert node["tx"] == 10
 
 Using `cmdx.Cached` is a lot faster than recomputing the value, sometimes by several orders of magnitude depending on the type of value being queried.
 
+#### Animation
+
+Assigning a dictionary to any numerical attribute turns those values into animation, with an appropriate curve type.
+
+```py
+node = createNode("transform")
+node["translateX"] = {1: 0.0, 5: 1.0, 10: 0.0}      # animCurveTL
+node["rotateX"] = {1: 0.0, 5: 1.0, 10: 0.0}         # animCurveTA
+node["scaleX"] = {1: 0.0, 5: 1.0, 10: 0.0}          # animCurveTL
+node["visibility"] = {1: True, 5: False, 10: True}  # animCurveTU
+
+# Alternatively
+node["v"].animate({1: False, 5: True, 10: False})
+```
+
+Where the `key` is the frame number (can be fractional) and `value` is the value at that frame. Interpolation is `cmdx.Linear` per default, but can be customised with..
+
+```py
+node["rotateX"].animate({1: 0.0, 5: 1.0, 10: 0.0}, cmdx.Smooth)
+```
+
+Currently available options:
+
+- `cmdx.Stepped`
+- `cmdx.Linear`
+- `cmdx.Smooth`
+
+Animation is *undoable* if used with a modifier.
+
+```py
+with cmdx.DagModifier() as mod:
+    node = mod.createNode("transform")
+    node["tx"] = {1: 0.0, 2: 5.0}
+```
+
 #### Time
 
 The `time` argument of `cmdx.getAttr` enables a query to yield results relative a specific point in time. The `time` argument of `Plug.read` offers this same convenience, only faster.
@@ -859,8 +894,7 @@ from maya import cmds
 node = cmdx.createNode("transform")
 
 # Make some animation
-tx = cmdx.create_node("animCurveTL")
-tx.keys(times=[1, 50, 100], values=[0.0, 10.0, 0.0], interpolation=cmdx.Linear)
+node["tx"] = {1: 0.0, 50: 10.0, 100: 0.0}
 
 # Query it
 node = cmdx.create_node("transform")

--- a/cmdx.py
+++ b/cmdx.py
@@ -2901,26 +2901,27 @@ class Plug(object):
             log.error("'%s': failed to read attribute" % self.path())
             raise
 
-    def animate(self, values):
-        """Treat values as time:value pairs and animate this attribute
+    if __maya_version__ > 2015:
+        def animate(self, values):
+            """Treat values as time:value pairs and animate this attribute
 
-        Example:
-            >>> _ = cmds.file(new=True, force=True)
-            >>> node = createNode("transform")
-            >>> node["tx"] = {1: 0.0, 5: 1.0, 10: 0.0}
-            >>> node["rx"] = {1: 0.0, 5: 1.0, 10: 0.0}
-            >>> node["sx"] = {1: 0.0, 5: 1.0, 10: 0.0}
-            >>> node["v"] = {1: True, 5: False, 10: True}
+            Example:
+                >>> _ = cmds.file(new=True, force=True)
+                >>> node = createNode("transform")
+                >>> node["tx"] = {1: 0.0, 5: 1.0, 10: 0.0}
+                >>> node["rx"] = {1: 0.0, 5: 1.0, 10: 0.0}
+                >>> node["sx"] = {1: 0.0, 5: 1.0, 10: 0.0}
+                >>> node["v"] = {1: True, 5: False, 10: True}
 
-        """
+            """
 
-        times, values = map(UiUnit(), values.keys()), values.values()
-        anim = createNode(_find_curve_type(self))
-        anim.keys(times, values)
-        anim["output"] >> self
+            times, values = map(UiUnit(), values.keys()), values.values()
+            anim = createNode(_find_curve_type(self))
+            anim.keys(times, values)
+            anim["output"] >> self
 
     def write(self, value):
-        if isinstance(value, dict):
+        if isinstance(value, dict) and __maya_version__ > 2015:
             return self.animate(value)
 
         if not getattr(self._modifier, "isDone", True):
@@ -3939,7 +3940,7 @@ def _python_to_mod(value, plug, mod):
 
     """
 
-    if isinstance(value, dict):
+    if isinstance(value, dict) and __maya_version__ > 2015:
         times, values = map(UiUnit(), value.keys()), value.values()
         curve_typ = _find_curve_type(plug)
 

--- a/cmdx.py
+++ b/cmdx.py
@@ -5785,15 +5785,11 @@ Distance4Attribute = Distance4
 
 
 # Support for multiple co-existing versions of apiundo.
-# NOTE: This is important for vendoring, as otherwise a vendored apiundo
-# could register e.g. cmds.apiUndo() first, causing a newer version
-# to inadvertently use this older command (or worse yet, throwing an
-# error when trying to register it again).
-command = "_cmdxApiUndo_%s" % __version__.replace(".", "_")
+command = "__cmdxUndo"
 
 # This module is both a Python module and Maya plug-in.
 # Data is shared amongst the two through this "module"
-name = "_cmdxShared_"
+name = "__cmdxShared"
 if name not in sys.modules:
     sys.modules[name] = types.ModuleType(name)
 
@@ -5884,6 +5880,8 @@ class _apiUndo(om.MPxCommand):
         # Facilitate the above precautionary measure
         shared.undo = None
         shared.redo = None
+
+        print("Yeppppppppppppppp ------------")
 
     def undoIt(self):
         shared.undos[self.undo]()

--- a/cmdx.py
+++ b/cmdx.py
@@ -3938,6 +3938,20 @@ def _python_to_mod(value, plug, mod):
         plug (Plug): Plug within which to write value
         mod (om.MDGModifier): Modifier to use for writing it
 
+    Example:
+        >>> mod = DagModifier()
+        >>> node = mod.createNode("transform")
+        >>> mod.set_attr(node["tx"], 5.0)
+        >>> mod.doIt()
+        >>> int(node["tx"].read())
+        5
+
+        # Support for applying a single value across compound children
+        >>> mod.set_attr(node["translate"], 10)
+        >>> mod.doIt()
+        >>> int(node["ty"].read())
+        10
+
     """
 
     if isinstance(value, dict) and __maya_version__ > 2015:

--- a/cmdx.py
+++ b/cmdx.py
@@ -2902,7 +2902,7 @@ class Plug(object):
             raise
 
     if __maya_version__ > 2015:
-        def animate(self, values):
+        def animate(self, values, interpolation=None):
             """Treat values as time:value pairs and animate this attribute
 
             Example:
@@ -2913,11 +2913,17 @@ class Plug(object):
                 >>> node["sx"] = {1: 0.0, 5: 1.0, 10: 0.0}
                 >>> node["v"] = {1: True, 5: False, 10: True}
 
+                # Direct function call
+                >>> node["ry"].animate({1: 0.0, 5: 1.0, 10: 0.0})
+
+                # Interpolation
+                >>> node["rz"].animate({1: 0.0, 5: 1.0, 10: 0.0}, Smooth)
+
             """
 
             times, values = map(UiUnit(), values.keys()), values.values()
             anim = createNode(_find_curve_type(self))
-            anim.keys(times, values)
+            anim.keys(times, values, interpolation=Linear)
             anim["output"] >> self
 
     def write(self, value):

--- a/cmdx.py
+++ b/cmdx.py
@@ -5880,8 +5880,12 @@ def install():
     tempdir = tempfile.gettempdir()
     tempfname = os.path.join(tempdir, unique_plugin)
 
-    # Rename ourselves..
-    shutil.copy(__file__, tempfname)
+    # We can't know whether we're a .pyc or .py file,
+    # but we need to copy the .py file *only*
+    fname = os.path.splitext(__file__)[0] + ".py"
+
+    # Copy *and overwrite*
+    shutil.copy(fname, tempfname)
 
     # Now we're guaranteed to not interfere
     # with other versions of cmdx. Win!

--- a/cmdx.py
+++ b/cmdx.py
@@ -3959,6 +3959,9 @@ def _python_to_mod(value, plug, mod):
 
     mplug = plug._mplug
 
+    if plug.isCompound and isinstance(value, (int, float)):
+        value = [value] * mplug.numChildren()
+
     if isinstance(value, (tuple, list)):
         for index, value in enumerate(value):
 

--- a/cmdx.py
+++ b/cmdx.py
@@ -4671,6 +4671,11 @@ def connect(a, b):
         mod.connect(a, b)
 
 
+def currentTime():
+    """Return current time in MTime format"""
+    return oma.MAnimControl.currentTime()
+
+
 class DGContext(om.MDGContext):
     """Context for evaluating the Maya DG
 
@@ -4679,16 +4684,6 @@ class DGContext(om.MDGContext):
 
     Arguments:
         time (float, om.MTime, optional): Time at which to evaluate context
-
-    Example:
-        >>> tm = createNode("transform")
-        >>> tm["tx"] = {1: 0.0, 5: 1.0, 10: 0.0}
-        >>> with DGContext(1, UiUnit()):
-        ...     assert tm["tx"].read() == 0.0
-        ...
-        >>> with DGContext(5, UiUnit()):
-        ...     assert tm["tx"].read() == 1.0
-        ...
 
     """
 
@@ -4704,12 +4699,21 @@ class DGContext(om.MDGContext):
         super(DGContext, self).__init__(*args)
         self._previous_context = None
 
-    # Context manager support in Maya 2018 and above
     if __maya_version__ >= 2018:
         def __enter__(self):
-            if self.getTime() == oma.MAnimControl.currentTime():
-                # No context needed
-                return
+            """Support for use as a context manager
+
+            Example:
+                >>> tm = createNode("transform")
+                >>> tm["tx"] = {1: 0.0, 5: 1.0, 10: 0.0}
+                >>> with DGContext(1, UiUnit()):
+                ...     assert tm["tx"].read() == 0.0
+                ...
+                >>> with DGContext(5, UiUnit()):
+                ...     assert tm["tx"].read() == 1.0
+                ...
+
+            """
 
             self._previous_context = self.makeCurrent()
             return self
@@ -4998,6 +5002,7 @@ list_relatives = listRelatives
 list_connections = listConnections
 connect_attr = connectAttr
 obj_exists = objExists
+current_time = currentTime
 
 # Speciality functions
 


### PR DESCRIPTION
- Refactor DGContext to be a context manager only in Maya 2018 and above
- Add node["attr"] = {1: 0.0} for animation
- Add Plug.animate

### Animate

Here's what you can do, to more easily add animation to any plug.

```python
node = createNode("transform")
node["tx"] = {1: 0.0, 5: 1.0, 10: 0.0}
node["rx"] = {1: 0.0, 5: 1.0, 10: 0.0}
node["sx"] = {1: 0.0, 5: 1.0, 10: 0.0}
node["v"] = {1: True, 5: False, 10: True}

# Alternatively
node["v"].animate({1: False, 5: True, 10: False})
```

Each of which creates an appropriate curve type, e.g. `animCurveTL` for `translateX` versus `animCurveTA` for `rotateY`.