### PR TITLE
Improve undo/redo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,17 +42,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v1
 
+      # We'll lock each version to one that works with both Python 2.7 and 3.7
       - name: pip install
         run: |
           wget https://bootstrap.pypa.io/pip/${{ matrix.pip }}
           mayapy get-pip.py --user
           mayapy -m pip install --user \
-            nose \
-            nose-exclude \
-            coverage \
-            flaky \
-            sphinx \
-            sphinxcontrib-napoleon
+            nose==1.3.7 \
+            nose-exclude==0.5.0 \
+            coverage==5.5 \
+            flaky==3.7.0 \
+            sphinx==1.8.5 \
+            sphinxcontrib-napoleon==0.7
 
         # Since 2019, this sucker throws an unnecessary warning if not declared
       - name: Environment

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,10 +24,6 @@ jobs:
 
       matrix:
        include:
-         - maya: "2015sp6"
-           pip: "2.7/get-pip.py"
-         - maya: "2016sp1"
-           pip: "2.7/get-pip.py"
          - maya: "2017"
            pip: "2.7/get-pip.py"
          - maya: "2018"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Environment
         run: |
           export XDG_RUNTIME_DIR=/var/tmp/runtime-root
+          export MAYA_DISABLE_ADP=1
 
       - name: Unittests
         run: |

--- a/cmdx.py
+++ b/cmdx.py
@@ -17,7 +17,7 @@ from maya import cmds
 from maya.api import OpenMaya as om, OpenMayaAnim as oma, OpenMayaUI as omui
 from maya import OpenMaya as om1, OpenMayaMPx as ompx1, OpenMayaUI as omui1
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"
 
 PY3 = sys.version_info[0] == 3
 

--- a/cmdx.py
+++ b/cmdx.py
@@ -6167,7 +6167,7 @@ def upAxis():
         >>> assert upAxis() == Vector(0, 1, 0)
 
     Returns:
-        string: "y" for Y-up, "z" for Z-up
+        Vector: (0, 1, 0) for Y-up, (0, 0, 1) for Z-up
 
     """
 

--- a/cmdx.py
+++ b/cmdx.py
@@ -47,8 +47,10 @@ ENABLE_UNDO = True
 ENABLE_PLUG_REUSE = True
 
 if PY3:
+    long = int
     string_types = str,
 else:
+    long = long
     string_types = str, basestring, unicode
 
 try:
@@ -4740,12 +4742,13 @@ class _BaseModifier(object):
 
         """
 
-        # Given that we perform lots of operations in a single context,
-        # let's establish our own chunk for it. We'll use the unique
-        # memory address of this particular instance as a name,
-        # such that we can identify it amongst the possible-nested
-        # modifiers once it exits.
-        cmds.undoInfo(chunkName="%x" % id(self), openChunk=True)
+        if self._opts["undoable"]:
+            # Given that we perform lots of operations in a single context,
+            # let's establish our own chunk for it. We'll use the unique
+            # memory address of this particular instance as a name,
+            # such that we can identify it amongst the possible-nested
+            # modifiers once it exits.
+            cmds.undoInfo(chunkName="%x" % id(self), openChunk=True)
 
         self.isContext = True
 
@@ -4760,8 +4763,21 @@ class _BaseModifier(object):
         try:
             self.redoIt()
 
+            # These all involve calling on cmds,
+            # which manages undo on its own.
+            self._doLockAttrs()
+            self._doKeyableAttrs()
+            self._doNiceNames()
+
         finally:
-            cmds.undoInfo(chunkName="%x" % id(self), closeChunk=True)
+            if self._opts["undoable"]:
+
+                # Make our commit within the current undo chunk,
+                # to combine the commands from the above special
+                # attribute edits which happen via maya.cmds
+                commit(self._modifier.undoIt, self._modifier.doIt)
+
+                cmds.undoInfo(chunkName="%x" % id(self), closeChunk=True)
 
     def __init__(self,
                  undoable=True,
@@ -4961,20 +4977,6 @@ class _BaseModifier(object):
 
     def redoIt(self):
         self.doIt()
-
-        # Append to undo *after* attempting to do, in case
-        # do actually fails in which case there's nothing to undo.
-        if self.isContext and self._opts["undoable"]:
-            # We'll commit doIt rather than redoIt, since
-            # the below special-commands are called via cmds
-            # and manage undo/redo on their own, without our help.
-            commit(self.undoIt, self.doIt)
-
-        # These all involve calling on cmds,
-        # which manages undo on its own.
-        self._doLockAttrs()
-        self._doKeyableAttrs()
-        self._doNiceNames()
 
     @record_history
     def createNode(self, type, name=None):
@@ -5178,7 +5180,8 @@ class _BaseModifier(object):
             plug = Plug(plug.node(), plug)
 
         assert not plug._mplug.isNull
-        assert plug.editable, "%s was locked or connected" % plug.path()
+        if not plug.editable:
+            raise LockedError("%s was locked or connected" % plug.path())
 
         # Support passing a cmdx.Plug as value
         if isinstance(value, Plug):
@@ -5192,6 +5195,38 @@ class _BaseModifier(object):
 
         if SAFE_MODE:
             self._modifier.doIt()
+
+    def smartSetAttr(self, plug, value):
+        """Convenience method for setAttr
+
+        If the plug being set is driven by another attribute,
+        attempt to set *its* value instead.
+
+        This is intended for semi-proxy attributes, which take
+        the place of an attribute elsewhere. When actual proxy
+        attributes are not possible (as they are garbage).
+
+        """
+
+        if plug.editable:
+            # No smarts necessary
+            return self.set_attr(plug, value)
+
+        if plug.locked:
+            # No amount of smarts is going to save us from this one
+            raise LockedError("%s was locked" % plug.path())
+
+        # Let's try and set the attribute on the connected plug instead
+        connection = plug.connection(plug=True,
+                                     source=True,
+                                     destination=False)
+
+        assert connection is not None, (
+            "Attribute was not locked, but also not connected? "
+            "Then what is it? This case isn't handled and is a bug."
+        )
+
+        return self.set_attr(connection, value)
 
     def trySetAttr(self, plug, value):
         try:
@@ -5603,6 +5638,7 @@ class _BaseModifier(object):
         add_attr = addAttr
         set_attr = setAttr
         try_set_attr = trySetAttr
+        smart_set_attr = smartSetAttr
         delete_attr = deleteAttr
         reset_attr = resetAttr
         try_connect = tryConnect
@@ -6069,7 +6105,10 @@ def delete(*nodes):
 
     # Use DAG modifier rather than DG, because
     # DG doesn't understand hierarchy.
-    with DagModifier() as mod:
+    # Do not make undoable, such that it may
+    # be used alongside :func:`commit` and within
+    # plug-ins that manage undo themselves
+    with DagModifier(undoable=False) as mod:
         for node in flattened:
             if isinstance(node, str):
                 node, node = node.rsplit(".", 1)
@@ -7067,6 +7106,22 @@ class _apiUndo(om.MPxCommand):
 
     def __del__(self):
         _apiUndo._aliveCount -= 1
+
+        # Relive whatever was held in memory
+        # This *should* always contain the undo ID
+        # of the current command instance. If it doesn't,
+        # the `shared` module must have been either
+        # edited or deleted outside of cmdx, such as
+        # if the module was reloaded.
+
+        # However, we can't afford throwing errors here,
+        # and errors here isn't a big whop anyway since they
+        # would be deleted and cleaned up on unloading
+        # of the `cmdx` module along with the `shared`
+        # instance from sys.module. E.g. on Maya restart.
+        shared.undos.pop(self.undoId, None)
+        shared.redos.pop(self.redoId, None)
+
         self.undoId = None
         self.redoId = None
 
@@ -7082,16 +7137,14 @@ class _apiUndo(om.MPxCommand):
         shared.redoId = None
 
     def undoIt(self):
-        try:
-            shared.undos.pop(self.undoId)()
-        except KeyError:
-            pass
+        # If the undo ID does not exist, it means
+        # we've erased commands still active in the undo
+        # queue, which isn't good. E.g. the cmdx module
+        # was reloaded.
+        shared.undos[self.undoId]()
 
     def redoIt(self):
-        try:
-            shared.redos.pop(self.redoId)()
-        except KeyError:
-            pass
+        shared.redos[self.redoId]()
 
     def isUndoable(self):
         # Without this, the above undoIt and redoIt will not be called

--- a/cmdx.py
+++ b/cmdx.py
@@ -6192,9 +6192,9 @@ def setUpAxis(axis=Y):
 
     if __maya_version__ >= 2019:
         if axis == Y:
-            om.MGlobal.setYAxisUp()
+            om.MGlobal.setYAxisUp(True)
         else:
-            om.MGlobal.setZAxisUp()
+            om.MGlobal.setZAxisUp(True)
     else:
         cmds.optionVar(stringValue=("upAxisDirection", axis))
         cmds.warning(

--- a/cmdx.py
+++ b/cmdx.py
@@ -667,8 +667,19 @@ class Node(object):
         Stats.NodeInitCount += 1
 
     def __del__(self):
+        """Clean up callbacks on garbage collection
+
+        These may/should clean up themselves alongside node
+        destruction, but in case they don't we make extra sure.
+
+        """
+
         for callback in self._state["callbacks"]:
-            om.MMessage.removeCallback(callback)
+            try:
+                om.MMessage.removeCallback(callback)
+            except RuntimeError:
+                pass
+
         self._state["callbacks"].clear()
 
     def _onDestroyed(self, mobject, _=None):
@@ -694,8 +705,8 @@ class Node(object):
         return self._mobject
 
     def isAlive(self):
-        """The node exists in the scene"""
-        return om.MObjectHandle(self._mobject).isAlive()
+        """The node exists somewhere in memory"""
+        return not self._destroyed
 
     @property
     def data(self):

--- a/cmdx.py
+++ b/cmdx.py
@@ -4445,7 +4445,7 @@ def _python_to_mod(value, plug, mod):
             _python_to_mod(value, plug[index], mod)
 
     else:
-        log.warning(
+        raise TypeError(
             "Unsupported plug type for modifier: %s" % type(value)
         )
         return False

--- a/cmdx.py
+++ b/cmdx.py
@@ -1653,6 +1653,7 @@ class DagNode(Node):
         if not type or type == self._fn.__class__(mobject).typeName:
             return cls(mobject)
 
+    @protected
     def lineage(self, type=None):
         """Yield parents all the way up a hierarchy
 
@@ -1677,6 +1678,7 @@ class DagNode(Node):
             yield parent
             parent = parent.parent(type)
 
+    @protected
     def children(self,
                  type=None,
                  filter=om.MFn.kTransform,
@@ -3111,20 +3113,51 @@ class Plug(object):
         """The nice name of this plug, visible in e.g. Channel Box
 
         Examples:
-            >>> node = createNode("transform")
+            >>> _new()
+            >>> node = createNode("transform", name="myTransform")
+
+            # Return pairs of nice names for compound attributes
+            >>> node["scale"].niceName == ("Scale X", "Scale Y", "Scale Z")
+            True
+
             >>> assert node["translateY"].niceName == "Translate Y"
             >>> node["translateY"].niceName = "New Name"
+            >>> assert node["translateY"].niceName == "New Name"
+
+            # The nice name is preserved on scene open
+            >>> _save()
+            >>> _load()
+            >>> node = encode("myTransform")
             >>> assert node["translateY"].niceName == "New Name"
 
         """
 
         # No way of retrieving this information via the API?
-        return cmds.attributeName(self.path(), nice=True)
+
+        if self.isArray or self.isCompound:
+            return tuple(
+                cmds.attributeName(plug.path(), nice=True)
+                for plug in self
+            )
+        else:
+            return cmds.attributeName(self.path(), nice=True)
 
     @niceName.setter
     def niceName(self, value):
-        fn = om.MFnAttribute(self._mplug.attribute())
-        fn.setNiceNameOverride(value)
+        elements = (
+            self
+            if self.isArray or self.isCompound
+            else [self]
+        )
+
+        for el in elements:
+            if el._mplug.isDynamic:
+                # Use setAttr as isKeyable doesn't
+                # persist on scene save for dynamic attributes.
+                cmds.addAttr(el.path(), edit=True, niceName=value)
+            else:
+                fn = om.MFnAttribute(el._mplug.attribute())
+                fn.setNiceNameOverride(value)
 
     @property
     def default(self):
@@ -5759,6 +5792,7 @@ class DagModifier(_BaseModifier):
         >>> mod = DagModifier()
         >>> parent = mod.createNode("transform", name="myParent")
         >>> child = mod.createNode("transform", name="myChild", parent=parent)
+        >>> _ = mod.createNode("transform", name="keepAlive", parent=parent)
         >>> mod.doIt()
         >>> "myParent" in cmds.ls()
         True
@@ -5769,7 +5803,7 @@ class DagModifier(_BaseModifier):
         >>> mod = DagModifier()
         >>> _ = mod.delete(child)
         >>> mod.doIt()
-        >>> parent.child() is None
+        >>> parent.child().name() == 'keepAlive'
         True
         >>> "myChild" in cmds.ls()
         False

--- a/cmdx.py
+++ b/cmdx.py
@@ -6157,28 +6157,45 @@ Y = "y"
 Z = "z"
 
 
-if __maya_version__ >= 2019:
-    def upAxis():
-        """Get the current up-axis as string
+def upAxis():
+    """Get the current up-axis as a Vector
 
-        Returns:
-            string: "y" for Y-up, "z" for Z-up
+    Examples:
+        >>> setUpAxis(Z)
+        >>> assert upAxis() == Vector(0, 0, 1)
+        >>> setUpAxis(Y)
+        >>> assert upAxis() == Vector(0, 1, 0)
 
-        """
+    Returns:
+        string: "y" for Y-up, "z" for Z-up
 
-        return om.MGlobal.upAxis()
+    """
 
-    def setUpAxis(axis=Y):
+    if __maya_version__ >= 2019:
+        return Vector(om.MGlobal.upAxis())
+
+    else:
+        if cmds.optionVar(query="upAxisDirection").lower() == "y":
+            return Vector(0, 1, 0)
+
+        else:
+            # Maya only supports two axes
+            return Vector(0, 0, 1)
+
+
+def setUpAxis(axis=Y):
+    """Set the current up-axis as Y or Z
+
+    Tested in :func:`upAxis`
+
+    """
+
+    if __maya_version__ >= 2019:
         if axis == Y:
             om.MGlobal.setYAxisUp()
         else:
             om.MGlobal.setZAxisUp()
-
-else:
-    def upAxis():
-        return cmds.optionVar(query="upAxisDirection")
-
-    def setUpAxis(axis=Y):
+    else:
         cmds.optionVar(stringValue=("upAxisDirection", axis))
         cmds.warning(
             "Changing up-axis via cmdx in Maya 2019 "

--- a/run_tests.py
+++ b/run_tests.py
@@ -44,8 +44,9 @@ if __name__ == "__main__":
     else:
         sys.stdout.write("Skipping coveralls\n")
 
-    # Graceful exit
-    standalone.uninitialize()
+    if os.name == "nt":
+        # Graceful exit, only Windows seems to like this consistently
+        standalone.uninitialize()
 
     # Trust but verify
     os._exit(0 if result.success else 1)

--- a/run_tests.py
+++ b/run_tests.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
     result = nose.main(
         argv=argv,
         addplugins=[flaky.FlakyPlugin()],
-        
+
         # We'll exit in our own way,
         # since Maya typically enjoys throwing
         # segfaults during cleanup of normal exits
@@ -44,5 +44,8 @@ if __name__ == "__main__":
     else:
         sys.stdout.write("Skipping coveralls\n")
 
-    # Good night Maya, you aweful segfaulter
+    # Graceful exit
+    standalone.uninitialize()
+
+    # Trust but verify
     os._exit(0 if result.success else 1)

--- a/tests.py
+++ b/tests.py
@@ -440,7 +440,7 @@ def test_modifier_first_error():
 def test_modifier_atomicity():
     """Modifier rolls back changes on failure"""
 
-    mod = cmdx.DagModifier()
+    mod = cmdx.DagModifier(atomic=True)
     node = mod.createNode("transform", name="UniqueName")
     mod.connect(node["translateX"], node["translateY"])
     mod.setAttr(node["translateY"], 5.0)


### PR DESCRIPTION
This is a big one. With undo/redo that actually works reliably, and that includes tests for the most common edge-cases.

- Greatly improved Undo/redo
- `SAFE_MODE` 2.0
- Removed `onDestroyed` and `onRemoved` callbacks. They were unused and unsafe.
- Removed `node["attr"] = value` during modifier-use, unused and not practical
- Removed plug reuse, it just isn't safe, and didn't make much difference to performance
- Refactored `DagModifier.lockAttr()` and `.niceName()` and `keyableAttr` for better integration with undo

<br>

### Undo/Redo

In the previous version, and every version since then, cmdx has had a checkered past with undo/redo. It's a hard problem, especially when tackled outside of the intended `MPxCommand` environment for which the API was designed.

But it's done. It's safe, and it's fast.

**Changed**

1. Nodes no longer carry their parent modifier, this prevented nodes from getting destroyed when they really should have been. Turns out, the MDagModifier instance actually prevents a destructor from being called. That's bad in all sorts of ways, since the MObject reference remains alive and well.
2. Plugs are no longer reused. The performance difference is neglible, and the stability improvements are complete.
3. Undo now discards of commited undo/redo functions to facilitate garbage collection and `~destruction` of nodes, both native and custom ones
4. API commands that intermingle with `maya.cmds` are now sandboxed appropriately, e.g. `DagModifier.lockAttr`

**Examples**

```py

def test_modifier_undo():
    new_scene()

    with cmdx.DagModifier() as mod:
        mod.createNode("transform", name="nodeA")
        mod.createNode("transform", name="nodeB")
        mod.createNode("transform", name="nodeC")

    assert "|nodeC" in cmdx.ls()
    cmds.undo()
    assert "|nodeC" not in cmdx.ls()


def test_modifier_locked():
    """Modifiers properly undo setLocked"""

    new_scene()
    node = cmdx.createNode("transform")
    assert not node["translateX"].locked

    with cmdx.DagModifier() as mod:
        mod.setLocked(node["translateX"], True)

    assert node["translateX"].locked
    cmds.undo()
    assert not node["translateX"].locked
    cmds.redo()
    assert node["translateX"].locked
    cmds.undo()
    assert not node["translateX"].locked


def test_modifier_keyable():
    """Modifiers properly undo setKeyable"""

    new_scene()
    node = cmdx.createNode("transform")
    assert node["translateX"].keyable

    with cmdx.DagModifier() as mod:
        mod.setKeyable(node["translateX"], False)

    assert not node["translateX"].keyable
    cmds.undo()
    assert node["translateX"].keyable
    cmds.redo()
    assert not node["translateX"].keyable
    cmds.undo()
    assert node["translateX"].keyable


def test_modifier_nicename():
    """Modifiers properly undo setNiceName"""

    new_scene()
    node = cmdx.createNode("transform")
    node["myName"] = cmdx.Double()
    assert node["myName"].niceName == "My Name"

    with cmdx.DagModifier() as mod:
        mod.setNiceName(node["myName"], "Nice Name")

    assert node["myName"].niceName == "Nice Name"
    cmds.undo()
    assert node["myName"].niceName == "My Name"
    cmds.redo()
    assert node["myName"].niceName == "Nice Name"
    cmds.undo()
    assert node["myName"].niceName == "My Name"


def test_modifier_plug_cmds_undo():
    """cmds and Modifiers undo in the same chunk"""

    new_scene()
    with cmdx.DagModifier() as mod:
        mod.createNode("transform", name="cmdxNode")
        cmds.createNode("transform", name="cmdsNode")

    assert "|cmdxNode" in cmdx.ls()
    assert "|cmdsNode" in cmdx.ls()

    cmds.undo()

    assert "|cmdxNode" not in cmdx.ls()
    assert "|cmdsNode" not in cmdx.ls()

    cmds.redo()

    assert "|cmdxNode" in cmdx.ls()
    assert "|cmdsNode" in cmdx.ls()

    cmds.undo()

    assert "|cmdxNode" not in cmdx.ls()
    assert "|cmdsNode" not in cmdx.ls()


def test_commit_undo():
    """commit is as stable as Modifiers"""

    new_scene()

    # Maintain reference to this
    test_commit_undo.node = None

    def do():
        test_commit_undo.node = cmdx.createNode("transform", name="nodeA")

    do()

    def undo():
        cmdx.delete(test_commit_undo.node)

    cmdx.commit(undo=undo, redo=do)

    assert "|nodeA" in cmdx.ls()

    cmds.undo()

    assert "|nodeA" not in cmdx.ls()

    cmds.redo()

    assert "|nodeA" in cmdx.ls()

    cmds.undo()

    assert "|nodeA" not in cmdx.ls()
```

### SAFE_MODE

There's always been a `SAFE_MODE` variable for cmdx, to try and produce a version that could not possibly crash. Any experimental feature - such as Undo in the early days - was put behind this flag.

This flag now makes this goal more true. It simply should not be able to crash when `SAFE_MODE` is active. It will however run about 10x slower due to the amount of added checking of validity it ends up doing.

```py
import os
os.environ["CMDX_SAFE_MODE"] = "Yes please"
import cmdx
```

> NOTE: The flag alters the contents of the module itself, so it can't be changed after import. Not unless you reload the module.

<br>

### Callbacks

There were two callbacks registered to cope with reusability of `MObject` instances. We now check for validity via `MObjectHandle` instead which relieves the use of callbacks. (And won't slow down your scene over time the more nodes become known to `cmdx`, which is enough of a plus on its own)

```py
# No longer possible
def on_removed():
  print("Some node was removed!")

node.onRemoved.append(on_removed)
```

<br>

### Modifiers

A little-known - as well as complex/obscure - feature of the `cmdx.MDagModifier` is that you can use the same syntax for setting attributes from within a modifier context manager.

```py
with cmdx.DagModifier as mod:
  node = mod.createNode("transform")
  node["tx"] = 5  # Actually calls mod.setAttr(node["tx"], 5)
```

In practice, this wasn't very smart. Consider this.

```py
nodeB = cmdx.createNode("transform")
with cmdx.DagModifier as mod:
  nodeA = mod.createNode("transform")
  nodeB["tx"] = 5
```

You'd expect `nodeB` to get set using this modifier, so it can be undone, because it happens within the context manager. When in fact it won't, since it isn't actually created by this modifier. And so, to leverage this convenience, you'd have to mix the two.

```py
nodeB = cmdx.createNode("transform")
with cmdx.DagModifier as mod:
  nodeA = mod.createNode("transform")
  nodeA["tx"] = 5  # OK  
  mod.setAttr(nodeB["tx"], 5)  # OK
```

And then there really isn't much point in having the convenience. This has now been removed, you now use `mod.setAttr` to set an attribute via the modifier, and `node[]` to set it outside of it. Simple.

### Plug Reuse

`MPlug` instanced used to be reused whenever you re-accessed a plug. But it isn't safe.. we can't know when an attribute is part of a node that has been deleted, or if the attribute itself has been deleted. Not without calls to `MObjectHandle.isAlive` and `MPlug.isNull` which costs as much as just finding the attribute over again.

<br>

### DagModifier.lockAttr

The modifier is essential for encapsulating a set of commands into a single undo block. But some things just aren't possible using a modifier, like locking an attribute, changing its nice name or editing its keyable state. These were tacked onto the cmdx modifier but aren't safe.. Locking of a *dynamic* attribute for example still can't happen via the API, and when we call `cmds.setAttr` in the midst of a MDagModifier, we've entangled the commands for undo. What should it do? Undo the locking first, and the modifier later? What if the modifier created the attribute we're locking? Not safe.

These have now been refactored to happen alongside a modifier and to play nice with undo.

1. Modifier is done, and commited to undo
2. Lock, keyable and nicenames are done via `maya.cmds`, which also commits to undo
3. Both commitments are added to the same undo chunk via `cmds.undoInfo(openChunk)`

And thus, they now play nice with undo.

The main limitation - aside from the performance penalty of translating a perfectly fine MObject into a full path and calling `maya.cmds` - is that `cmds.addAttr(niceName=)` only works on *dynamic attributes*. Bummer.