### PR TITLE
Fool-proof plug-in load

### DIFF
--- a/cmdx.py
+++ b/cmdx.py
@@ -19,7 +19,7 @@ from maya import cmds
 from maya.api import OpenMaya as om, OpenMayaAnim as oma, OpenMayaUI as omui
 from maya import OpenMaya as om1, OpenMayaMPx as ompx1, OpenMayaUI as omui1
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 PY3 = sys.version_info[0] == 3
 

--- a/cmdx.py
+++ b/cmdx.py
@@ -4097,7 +4097,8 @@ class TransformationMatrix(om.MTransformationMatrix):
         return super(TransformationMatrix, self).setScale(seq, space)
 
     def rotation(self, asQuaternion=False):
-        return super(TransformationMatrix, self).rotation(asQuaternion)
+        rotation = super(TransformationMatrix, self).rotation(True)
+        return Quaternion(rotation) if asQuaternion else Euler(rotation)
 
     def setRotation(self, rot):
         """Interpret three values as an euler rotation"""
@@ -6369,7 +6370,8 @@ def ls(*args, **kwargs):
 
 
 def selection(*args, **kwargs):
-    return list(map(encode, cmds.ls(*args, selection=True, **kwargs)))
+    kwargs["selection"] = True
+    return ls(*args, **kwargs)
 
 
 def createNode(type, name=None, parent=None):

--- a/cmdx.py
+++ b/cmdx.py
@@ -4932,15 +4932,24 @@ def _python_to_mod(value, plug, mod):
     return True
 
 
-def exists(path):
-    """Return whether any node at `path` exists"""
+def exists(path, strict=True):
+    """Return whether any node at `path` exists
 
-    selectionList = om.MSelectionList()
+    Arguments:
+        path (str): Full or partial path to node
+        strict (bool, optional): Error if the path isn't a full match,
+            including namespace.
+
+    """
 
     try:
-        selectionList.add(path)
+        node = encode(path)
     except RuntimeError:
         return False
+
+    if strict:
+        return node.path(namespace=True) == path
+
     return True
 
 
@@ -7635,7 +7644,6 @@ def install():
     tempdir = os.path.expanduser("~/maya/plug-ins")
 
     try:
-        print("Making %s" % tempdir)
         os.makedirs(tempdir)
 
     except OSError as e:

--- a/cmdx.py
+++ b/cmdx.py
@@ -1290,6 +1290,19 @@ class Node(object):
                              destination=destination,
                              connections=connection), None)
 
+    def inputs(self,
+               type=None,
+               unit=None,
+               plugs=False,
+               connections=False):
+        """Return input connections from :func:`connections()`"""
+        return self.connections(type=type,
+                                unit=unit,
+                                plugs=plugs,
+                                source=True,
+                                destination=False,
+                                connections=connections)
+
     def input(self,
               type=None,
               unit=None,

--- a/cmdx.py
+++ b/cmdx.py
@@ -268,16 +268,16 @@ def add_metaclass(metaclass):
 
     def wrapper(cls):
         orig_vars = cls.__dict__.copy()
-        slots = orig_vars.get('__slots__')
+        slots = orig_vars.get("__slots__")
         if slots is not None:
             if isinstance(slots, str):
                 slots = [slots]
             for slots_var in slots:
                 orig_vars.pop(slots_var)
-        orig_vars.pop('__dict__', None)
-        orig_vars.pop('__weakref__', None)
-        if hasattr(cls, '__qualname__'):
-            orig_vars['__qualname__'] = cls.__qualname__
+        orig_vars.pop("__dict__", None)
+        orig_vars.pop("__weakref__", None)
+        if hasattr(cls, "__qualname__"):
+            orig_vars["__qualname__"] = cls.__qualname__
         return metaclass(cls.__name__, cls.__bases__, orig_vars)
     return wrapper
 
@@ -2843,7 +2843,7 @@ class Plug(object):
     @property
     def arrayIndices(self):
         if not self._mplug.isArray:
-            raise TypeError('{} is not an array'.format(self.path()))
+            raise TypeError("{} is not an array".format(self.path()))
 
         # Convert from `p_OpenMaya_py2.rItemNot3Strs` to list
         return list(self._mplug.getExistingArrayAttributeIndices())
@@ -3806,9 +3806,14 @@ class Plug(object):
             2
             >>> b["arrayAttr"] = Long(array=True)
             >>> b["arrayAttr"][0] >> a["ihi"]
+            >>> b["arrayAttr"][1] >> a["visibility"]
             >>> a["ihi"].connection() == b
             True
             >>> a["ihi"].connection(plug=True) == b["arrayAttr"][0]
+            True
+            >>> a["visibility"].connection(plug=True) == b["arrayAttr"][1]
+            True
+            >>> b["arrayAttr"][1].connection(plug=True) == a["visibility"]
             True
 
         """

--- a/cmdx.py
+++ b/cmdx.py
@@ -4110,7 +4110,7 @@ class TransformationMatrix(om.MTransformationMatrix):
         return super(TransformationMatrix, self).setScale(seq, space)
 
     def rotation(self, asQuaternion=False):
-        rotation = super(TransformationMatrix, self).rotation(True)
+        rotation = super(TransformationMatrix, self).rotation(asQuaternion)
         return Quaternion(rotation) if asQuaternion else Euler(rotation)
 
     def setRotation(self, rot):

--- a/cmdx.py
+++ b/cmdx.py
@@ -1290,19 +1290,6 @@ class Node(object):
                              destination=destination,
                              connections=connection), None)
 
-    def inputs(self,
-               type=None,
-               unit=None,
-               plugs=False,
-               connections=False):
-        """Return input connections from :func:`connections()`"""
-        return self.connections(type=type,
-                                unit=unit,
-                                plugs=plugs,
-                                source=True,
-                                destination=False,
-                                connections=connections)
-
     def input(self,
               type=None,
               unit=None,


### PR DESCRIPTION
Fixes #61 

**Special Case Fix**

This also addresses a special case of querying connections to elements of an array.

```py
b["arrayAttr"] = Long(array=True)
b["arrayAttr"][0] >> a["ihi"]
assert a["ihi"].connection() == b
assert a["ihi"].connection(plug=True) == b["arrayAttr"][0]
```

This didn't use to work, as the plug was automatically converted from a networked to non-networked plug using `findPlug`. And it didn't like indices in the name given, e.g. `worldMatrix[0]`.

**strict=True**

Turns out, `MSelectionList.add()` is lazy. It'll accept the shortest path to a node, such as `myNode` even though the actual name is `someNamespace:|myNode`. So, does `myNode` exist? No! That's what strict does.

```py
assert cmdx.exist("myNode", strict=False)
assert not cmdx.exist("myNode", strict=True)
assert not cmdx.exist("myNode")  # New default
```