### PR TITLE
Fix Node.isA bug when checking multiple types

### DIFF
--- a/cmdx.py
+++ b/cmdx.py
@@ -841,7 +841,12 @@ class Node(object):
         elif isinstance(type, string_types):
             return type == self._fn.typeName
         elif isinstance(type, (tuple, list)):
-            return self._fn.typeName in type or self._fn.typeId in type
+            for t in type:
+                if isinstance(t, string_types) and t == self._fn.typeName:
+                    return True
+                if isinstance(t, om.MTypeId) and t == self._fn.typeId:
+                    return True
+            return False
         elif isinstance(type, int):
             return self._mobject.hasFn(type)
         cmds.warning("Unsupported argument passed to isA('%s')" % type)

--- a/cmdx.py
+++ b/cmdx.py
@@ -834,6 +834,8 @@ class Node(object):
             True
             >>> node.isA(kShape)
             False
+            >>> node.isA((kShape, kTransform))
+            True
 
         """
         if isinstance(type, om.MTypeId):
@@ -841,12 +843,7 @@ class Node(object):
         elif isinstance(type, string_types):
             return type == self._fn.typeName
         elif isinstance(type, (tuple, list)):
-            for t in type:
-                if isinstance(t, string_types) and t == self._fn.typeName:
-                    return True
-                if isinstance(t, om.MTypeId) and t == self._fn.typeId:
-                    return True
-            return False
+            return any(self.isA(t) for t in type)
         elif isinstance(type, int):
             return self._mobject.hasFn(type)
         cmds.warning("Unsupported argument passed to isA('%s')" % type)


### PR DESCRIPTION
Because Maya is a big dumb dumb and errors out if you dare compare an MTypeId with anything other than another MTypeId:

```python
node = cmdx.createNode("transform")
node.isA((cmdx.tTransform, cmdx.tMesh))
# Error: MTypeId expected
# Traceback (most recent call last):
#   File "<maya console>", line 2, in <module>
#   File "C:\Users\mitch\code\cmdx\cmdx.py", line 844, in isA
#     return self._fn.typeName in type or self._fn.typeId in type
# TypeError: MTypeId expected # 
```

Let me know if there;s a better way to solve this!