### PR TITLE
Walk connections and other tweaks

### DIFF
--- a/cmdx.py
+++ b/cmdx.py
@@ -1400,12 +1400,6 @@ class Node(object):
             plugs (bool, optional): Return plugs, rather than nodes
             connections (bool, optional): Return tuples of the connected plugs
 
-        Example:
-            >>> node1 = createNode("transform")
-            >>> node1 = createNode("transform")
-            >>> node1 = createNode("transform")
-            >>> node2 =
-
         """
 
         it = ItDg(self._mobject, direction=direction, traversal=traversal, level=level)
@@ -2066,7 +2060,7 @@ class DagNode(Node):
             mobj = it.currentItem()
             node = DagNode(mobj)
 
-            if node.isA(type):
+            if type is None or node.isA(type):
                 if not contains or node.shape(type=contains):
                     if not query or node.query(query):
                         yield node

--- a/cmdx.py
+++ b/cmdx.py
@@ -1400,6 +1400,32 @@ class Node(object):
             plugs (bool, optional): Return plugs, rather than nodes
             connections (bool, optional): Return tuples of the connected plugs
 
+        Example:
+            >>> a = createNode("transform")
+            >>> b = createNode("multiplyDivide")
+            >>> c = createNode("transform")
+            >>> d = createNode("transform")
+            >>> a["tx"] >> b["input1X"]
+            >>> b["outputX"] >> c["tx"]
+            >>> a["ty"] >> d["ty"]
+            >>> cons = list(a.walkConnections())
+            >>> all(x in cons for x in (b, c, d))
+            True
+            >>> it = a.walkConnections(filter="transform")
+            >>> next(it) == d
+            True
+            >>> it = c.walkConnections(type="transform", direction=ItDg.kUpstream)
+            >>> next(it) == a
+            True
+            >>> cons = list(a.walkConnections(plugs=True, connections=True))
+            >>> mplugs = [(x.plug(), y.plug()) for x, y in cons]
+            >>> (b["input1X"].plug(), a["tx"].plug()) in mplugs
+            True
+            >>> (c["tx"].plug(), b["outputX"].plug()) in mplugs
+            True
+            >>> (d["ty"].plug(), a["ty"].plug()) in mplugs
+            True
+
         """
 
         it = ItDg(self._mobject, direction=direction, traversal=traversal, level=level)

--- a/cmdx.py
+++ b/cmdx.py
@@ -1383,7 +1383,7 @@ class Node(object):
                         filter=None,
                         direction=ItDg.kDownstream,
                         traversal=ItDg.kDepthFirst,
-                        level=ItDg.kPlugLevel,
+                        level=ItDg.kNodeLevel,
                         plugs=False,
                         connections=False):
         """Walk connections either upstream or downstream from this node
@@ -1394,7 +1394,7 @@ class Node(object):
             direction (int, optional): Walk upstream or downstream through the graph
             traversal (int, optional): Traversal method, depth or breadth first
             level (int, optional): Level of iteration through the graph,
-                defaults to plug level. Iterating at plug level will return
+                defaults to node level. Iterating at plug level will return
                 every connection between this plug and another node, whereas
                 node level would only return one connection to another node.
             plugs (bool, optional): Return plugs, rather than nodes


### PR DESCRIPTION
## walkConnections
Walk through DG connections upstream or downstream starting from either a `Plug` or a `Node`. Defaults to depth first search but can be changed to breadth first.

```python
a = cmdx.createNode("transform")
b = cmdx.createNode("multiplyDivide")
c = cmdx.createNode("transform")
d = cmdx.createNode("transform")
a["tx"] >> b["input1X"]
b["outputX"] >> c["tx"]
a["ty"] >> d["ty"]
list(a.walkConnections())
# Result: [multiplyDivide1, |transform2, |transform3] # 
```

The `type` argument limits the return type.

```python
list(a.walkConnections(type="transform"))
# Result: [|transform2, |transform3] # 
```

Whereas `filter` prunes the iterator, stopping traversal over incorrect node types.

```python
list(a.walkConnections(filter="transform")) # Don't traverse over the multiplyDivide node
# Result: [|transform3] #
```

Return plugs with `plugs`

```python
[x.path() for x in a.walkConnections(plugs=True)]
# Result: ['multiplyDivide1.input1X', '|transform2.translateX', '|transform3.translateY'] #
```

`connections` will return a tuple of both plugs/nodes in the connection.

```python
it = a.walkConnections(connections=True)
next(it)
# Result: (multiplyDivide1, |transform1) # 

it = a.walkConnections(plugs=True, connections=True)
con = next(it)
con[0].path(), con[1].path()
# Result: ('multiplyDivide1.input1X', '|transform1.translateX') # 
```

`level` controls the level of detail when traversing the DG, the default kPlugLevel will return multiple connections between two nodes, whereas kNodeLevel will only return the first connection between two nodes.

`upstream` and `downstream` are also provided as convenience methods for `walkConnections`.

## Plug methods for getting parent plugs
- `isElement` and `isChild` for checking if this plug is part of an array or compound.
- `parent` returns the parent of this element or child plug.
- `index` returns the index of this element or child plug.

## Extra arguments to Node.descendents
- `traversal` for choosing between depth or breadth first.
- `query` for querying attributes like in `Node.children`.
- `contains` for only returning node with a certain shape.

Side note, should it be spelled descendants not descendents?

## Node.query
I've pulled the `query` argument from `Node.children` so it can be used on its own and maintained in the one place. It returns `True` if the query is successful otherwise `False`.

## MatrixType.\_\_invert\_\_
Supports the `~` operator for inverting a matrix.

## Added some missing PEP8 aliases for Plug
There were a couple of method/properties lacking a PEP8 alias.

---

While working on these I noticed a few methods had a `type` argument for checking node types as well as a `filter` argument for checking if the object has a MFn function set. Could these not be rolled into a single `type` argument with a `Node.isA` check? That way you can have exact type checking against a `MTypeId` or `typeName`, or more permissive type checking against an MFn constant. It would also allow type checking against a tuple of types, which isn't possible with some methods at the moment.

I've noticed this `filter` argument in these methods:
- `Node.parent`
- `Node.lineage`
- `Node.children`
- `Node.child`
- `Node.siblings`
- `Node.sibling`

I'd be happy to refactor these methods to use `Node.isA` if you agree and update this PR.