### PR TITLE
Undo WIP

### DIFF
--- a/cmdx.py
+++ b/cmdx.py
@@ -2615,7 +2615,7 @@ class Plug(object):
             ...
             TypeError: |mynode.visibility does not support indexing
             >>> node["translate"][2] = 5.1
-            >>> node["translate"][2].read()
+            >>> '%.1f' % node["translate"][2].read()
             5.1
 
             # Elements are accessed by logical index, rather than physical

--- a/cmdx.py
+++ b/cmdx.py
@@ -3308,7 +3308,7 @@ class Plug(object):
 
     @niceName.setter
     @use_modifier
-    def niceName(self, value):
+    def niceName(self, value, _mod=None):
         _mod.setNiceName(self, value)
 
     @property
@@ -6330,24 +6330,22 @@ def createNode(type, name=None, parent=None):
     """
 
     kwargs = {}
+    fn = GlobalDependencyNode
 
     if name:
         kwargs["name"] = name
 
     if parent:
-        kwargs["parent"] = parent
+        kwargs["parent"] = parent._mobject
+        fn = GlobalDagNode
 
-    if _BaseModifier.current:
-        node = _BaseModifier.current.createNode(type, **kwargs)
-    else:
-        try:
-            with DagModifier() as mod:
-                node = mod.createNode(type, **kwargs)
-        except TypeError:
-            with DGModifier() as mod:
-                node = mod.createNode(type, **kwargs)
+    try:
+        mobj = fn.create(type, **kwargs)
+    except RuntimeError as e:
+        log.debug(str(e))
+        raise TypeError("Unrecognized node type '%s'" % type)
 
-    return node
+    return Node(mobj, exists=False)
 
 
 def getAttr(attr, type=None, time=None):

--- a/cmdx.py
+++ b/cmdx.py
@@ -6335,7 +6335,7 @@ def createNode(type, name=None, parent=None):
         kwargs["name"] = name
 
     if parent:
-        kwargs["parent"] = parent._mobject
+        kwargs["parent"] = parent
 
     if _BaseModifier.current:
         node = _BaseModifier.current.createNode(type, **kwargs)

--- a/cmdx.py
+++ b/cmdx.py
@@ -2616,8 +2616,8 @@ class Plug(object):
             ...
             TypeError: |mynode.visibility does not support indexing
             >>> node["translate"][2] = 6.1
-            >>> node["translate"][2].read()
-            6.1
+            >>> '%.1f' % node["translate"][2].read()
+            '6.1'
 
             # Elements are accessed by logical index, rather than physical
             >>> tm = createNode("transform")

--- a/cmdx.py
+++ b/cmdx.py
@@ -6337,7 +6337,7 @@ def createNode(type, name=None, parent=None):
         kwargs["name"] = name
 
     if parent:
-        kwargs["parent"] = parent._mobject
+        kwargs["parent"] = parent
 
     # Try to use current modifier if we have one
     if _BaseModifier.current:

--- a/cmdx.py
+++ b/cmdx.py
@@ -2614,9 +2614,9 @@ class Plug(object):
             Traceback (most recent call last):
             ...
             TypeError: |mynode.visibility does not support indexing
-            >>> node["translate"][2] = 5.1
-            >>> '%.1f' % node["translate"][2].read()
-            5.1
+            >>> node["translate"][2] = 6.1
+            >>> node["translate"][2].read()
+            6.1
 
             # Elements are accessed by logical index, rather than physical
             >>> tm = createNode("transform")

--- a/test_performance.py
+++ b/test_performance.py
@@ -98,7 +98,8 @@ def test_createNode_performance():
     )
 
     for contender, test in versions:
-        Compare(contender, "createNode", test, setup=New)
+        with cmdx.DagModifier():
+            Compare(contender, "createNode", test, setup=New)
 
     cmdx_vs_cmds = (
         timings["createNode"]["cmds"]["percall"] /

--- a/tests.py
+++ b/tests.py
@@ -410,35 +410,6 @@ def test_superclass():
     assert isinstance(node, cmdx.Node)
 
 
-@with_setup(new_scene)
-def test_undo():
-    """Undo works without modifiers"""
-
-    nodeA = cmdx.createNode("transform", name="nodeA")
-    nodeA["myAttr"] = cmdx.Double(default=1.0)
-    nodeA["myAttr"] = 5.0
-
-    assert "|nodeA" in cmdx.ls()
-    assert_equals(nodeA["myAttr"], 5.0)
-    cmds.undo()
-    assert_equals(nodeA["myAttr"], 1.0)
-    cmds.undo()
-    assert_equals(nodeA.hasAttr("myAttr"), False)
-    cmds.undo()
-    assert "|nodeA" not in cmdx.ls()
-
-    # still groups undo inside modifier
-    with cmdx.DagModifier():
-        nodeB = cmdx.createNode("transform", name="nodeB")
-        nodeB["myAttr"] = cmdx.Double(default=5.0)
-
-    assert "|nodeB" in cmdx.ls()
-    assert_equals(nodeB.hasAttr("myAttr"), True)
-    assert_equals(nodeB["myAttr"], 5.0)
-    cmds.undo()
-    assert "|nodeB" not in cmdx.ls()
-
-
 def test_modifier_badtype():
     """Modifier can't create non-existent types"""
 

--- a/tests.py
+++ b/tests.py
@@ -410,6 +410,36 @@ def test_superclass():
     assert isinstance(node, cmdx.Node)
 
 
+@with_setup(new_scene)
+def test_undo():
+    """Undo works without modifiers"""
+
+    nodeA = cmdx.createNode("transform", name="nodeA")
+    nodeA["myAttr"] = cmdx.Double(default=1.0)
+    nodeA["myAttr"] = 5.0
+
+    assert "|nodeA" in cmdx.ls()
+    assert_equals(nodeA["myAttr"], 5.0)
+    cmds.undo()
+    assert_equals(nodeA["myAttr"], 1.0)
+    cmds.undo()
+    assert_equals(nodeA.hasAttr("myAttr"), False)
+    cmds.undo()
+    assert "|nodeA" not in cmdx.ls()
+
+    # still groups undo inside modifier
+    with cmdx.DagModifier():
+        nodeB = cmdx.createNode("transform", name="nodeB")
+        nodeB["myAttr"] = cmdx.Double(default=1.0)
+        nodeB["myAttr"] = 5.0
+
+    assert "|nodeB" in cmdx.ls()
+    assert_equals(nodeB.hasAttr("myAttr"), 5.0)
+    assert_equals(nodeB["myAttr"], 5.0)
+    cmds.undo()
+    assert "|nodeB" not in cmdx.ls()
+
+
 def test_modifier_badtype():
     """Modifier can't create non-existent types"""
 

--- a/tests.py
+++ b/tests.py
@@ -430,11 +430,10 @@ def test_undo():
     # still groups undo inside modifier
     with cmdx.DagModifier():
         nodeB = cmdx.createNode("transform", name="nodeB")
-        nodeB["myAttr"] = cmdx.Double(default=1.0)
-        nodeB["myAttr"] = 5.0
+        nodeB["myAttr"] = cmdx.Double(default=5.0)
 
     assert "|nodeB" in cmdx.ls()
-    assert_equals(nodeB.hasAttr("myAttr"), 5.0)
+    assert_equals(nodeB.hasAttr("myAttr"), True)
     assert_equals(nodeB["myAttr"], 5.0)
     cmds.undo()
     assert "|nodeB" not in cmdx.ls()


### PR DESCRIPTION
Hey after talking about undo in the other PR I was messing around trying to get undo to work for the nicer syntax. I've come up with something that seems to work, but there's probably some huge flaw that I'm missing. Take a look and see if you think it's worth pursuing.

### Undo without using modifiers directly
```python
node = cmdx.createNode("transform")
node in cmdx.ls()
# Result: True # 

node["ty"] = 10
node["ty"]
# Result: 10.0 # 

cmds.undo()
node["ty"]
# Result: 0.0 #

cmds.undo()
node in cmdx.ls()
# Result: False #
```

### Using modifiers to group commands for undo
```python
nodeA = cmdx.createNode("transform")
nodeB = cmdx.createNode("transform")

with cmdx.DGModifier():
    nodeA["tx"] = 5
    nodeA["tx"] >> nodeB["tx"]

nodeB["tx"]
# Result: 5.0 # 

cmds.undo()
nodeB["tx"].connected
# Result: False # 
nodeA["tx"]
# Result: 0.0 #
```

### Using modifiers the old way works too
```python
with cmdx.DagModifier() as mod:
    node = mod.createNode("transform")
    mod.setAttr(node["tx"], 5)

node["tx"]
# Result: 5.0 # 
cmds.undo()
node in cmdx.ls()
# Result: False # 
```

### How it works 
Commands that edit the DG are wrapped by the `@use_modifier` decorator. This decorator gets the active modifier (`DGModifier` or `DagModifier`) if there is one, otherwise creates a new one for the operation. It then inserts the modifier into the `_mod` keyword argument, the function can then call modifier methods via `_mod`.

### Limitations
Querying attrs after setting them inside a modifier won't give you up to date information (just like before when using a modifier).
```python
with cmdx.DagModifier():
    node = createNode("transform")
    node["tx"] = 20
    value = node["tx"].read()

value
# Result: 0.0 #
```

Undo is more expensive than no undo 😄, the main cost comes from having to create new instances of `DGModifier` or `DagModifier`. The cost of this makes creating new nodes more in line with the speed of `cmds.createNode`.
```python
cmdx.createNode("transform") # new DagModifier
cmdx.createNode("transform") # new DagModifier
cmdx.createNode("transform") # new DagModifier
cmdx.createNode("transform") # new DagModifier
```
However, most of the cost can be avoided by calling from within a `DagModifier` or `DGModifier` block.
```python
with DagModifier(): # uses this instance for all nodes created within
    cmdx.createNode("transform")
    cmdx.createNode("transform")
    cmdx.createNode("transform")
    cmdx.createNode("transform")
```
If you take a look at the `test_performance.py` file I've wrapped the test in a modifier, and you can see that the performance tests still pass without changing the comparison value to `cmds` or `maya.api.OpenMaya`.