### PR TITLE
Undoable Animation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
             nose-exclude==0.5.0 \
             coverage==5.5 \
             flaky==3.7.0 \
-            docutils<0.18 \
+            docutils==17.1 \
             sphinx==1.8.5 \
             sphinxcontrib-napoleon==0.7
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,7 @@ jobs:
             nose-exclude==0.5.0 \
             coverage==5.5 \
             flaky==3.7.0 \
+            docutils<0.18 \
             sphinx==1.8.5 \
             sphinxcontrib-napoleon==0.7
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
             nose-exclude==0.5.0 \
             coverage==5.5 \
             flaky==3.7.0 \
-            docutils==17.1 \
+            docutils==0.17.1 \
             sphinx==1.8.5 \
             sphinxcontrib-napoleon==0.7
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,37 @@ $ pip install cmdx
 
 <br>
 
+### Vendoring
+
+> Note: Advanced topic, you can skip this
+
+Unlike PyMEL and cmds, `cmdx` is designed to be distributed alongside your tool. That means multiple copies of `cmdx` can coincide within the same Maya/Python session. But because the way [Undo/Redo](#undo) is handled, the `cmdx.py` module is also loaded as a Maya command plug-in.
+
+You can either ignore this, things to look out for is errors during undo coming from another tool or global module directory, even though the command came from your tool. Alternatively, you can follow this recommendation.
+
+```bash
+mytool/
+    vendor/
+        __init__.py
+        cmdx_mytool.py
+```
+
+From here, you can either `from .vendor import cmdx_mytool as cmdx` or you can put the following into the `__init__.py` of the `vendor/` package.
+
+```py
+from . import cmdx_mytool as cmdx
+```
+
+This would then allow your users to call..
+
+```py
+from mytool.vendor import cmdx
+```
+
+..as though the module was called just `cmdx.py`.
+
+<br>
+
 ### What is novel?
 
 With [so many options](#comparison) for interacting with Maya, when or why should you choose `cmdx`?
@@ -1091,6 +1122,20 @@ In addition to its default methods, it can also do multiplication with a vector.
 q = Quaternion(0, 0, 0, 1)
 v = Vector(1, 2, 3)
 assert isinstance(q * v, Vector)
+```
+
+##### Conversions
+
+Python's `math` library provides a few convenience functions for converting `math.degrees` to `math.radians`. `cmdx` extends this with `cmdx.time` and `cmdx.frame`.
+
+```py
+radians = cmdx.radians(5)
+degrees = cmdx.degrees(radians)
+assert degrees = 5
+
+time = cmdx.time(frame=10)
+frame = cmdx.frame(time=time)
+assert frame == 10
 ```
 
 ##### Available types

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ On average, `cmdx` is **140x faster** than [PyMEL](https://github.com/LumaPictur
 
 ##### Status
 
-[![](https://img.shields.io/pypi/v/cmdx?color=steelblue&label=PyPI)](https://github.com/mottosso/cmdx/) [![](https://img.shields.io/pypi/pyversions/cmdx?color=steelblue)](https://pypi.org/project/cmdx)
+[![](https://img.shields.io/pypi/v/cmdx?color=steelblue&label=PyPI)](https://pypi.org/project/cmdx/) [![](https://img.shields.io/pypi/pyversions/cmdx?color=steelblue)](https://pypi.org/project/cmdx)
 
 | Maya    | Status
 |:----------|:----

--- a/cmdx.py
+++ b/cmdx.py
@@ -18,7 +18,7 @@ from maya import cmds
 from maya.api import OpenMaya as om, OpenMayaAnim as oma, OpenMayaUI as omui
 from maya import OpenMaya as om1, OpenMayaMPx as ompx1, OpenMayaUI as omui1
 
-__version__ = "0.6.3"
+__version__ = "0.6.2"
 
 IS_VENDORED = "." in __name__
 

--- a/cmdx.py
+++ b/cmdx.py
@@ -2295,14 +2295,26 @@ class AnimCurve(Node):
             else:
                 self._fna.addKey(time, value, interpolation, interpolation)
 
-        def keys(self, times, values, interpolation=Linear):
+        def keys(self, times, values, interpolation=Linear, change=None):
             times = list(map(
                 lambda t: Seconds(t) if isinstance(t, (float, int)) else t,
                 times
             ))
 
             try:
-                self._fna.addKeys(times, values)
+                keepExistingKeys = False  # Default
+                args = [
+                    times,
+                    values,
+                    oma.MFnAnimCurve.kTangentGlobal,
+                    oma.MFnAnimCurve.kTangentGlobal,
+                    keepExistingKeys,
+                ]
+
+                if change is not None:
+                    args += [change]
+
+                self._fna.addKeys(*args)
 
             except RuntimeError:
                 # The error provided by Maya aren't very descriptive,
@@ -4468,6 +4480,15 @@ class EulerRotation(om.MEulerRotation):
         kZYX: 'zyx'
     }
 
+    enumToOrder = [
+        kXYZ,
+        kXZY,
+        kYXZ,
+        kYZX,
+        kZXY,
+        kZYX
+    ]
+
     if ENABLE_PEP8:
         as_quaternion = asQuaternion
         as_matrix = asMatrix
@@ -4922,21 +4943,22 @@ def _python_to_mod(value, plug, mod):
     if isinstance(value, dict) and __maya_version__ > 2015:
         times, values = map(UiUnit(), value.keys()), value.values()
         curve_typ = _find_curve_type(plug)
-        anim = plug.input(type=curve_typ)
+        curve = plug.input(type=curve_typ)
 
-        if not anim:
+        if not curve:
             if isinstance(mod, DGModifier):
-                anim = mod.createNode(curve_typ)
+                curve = mod.createNode(curve_typ)
             else:
                 # The DagModifier can't create DG nodes
                 with DGModifier() as dgmod:
-                    anim = dgmod.createNode(curve_typ)
+                    curve = dgmod.createNode(curve_typ)
 
-            mod.connect(anim["output"]._mplug, plug._mplug)
+            mod.connect(curve["output"]._mplug, plug._mplug)
 
-        anim.keys(times, values)
+        change = oma.MAnimCurveChange()
+        curve.keys(times, values, change=change)
 
-        return True
+        return change
 
     mplug = plug._mplug
 
@@ -5076,6 +5098,14 @@ def encode(path):  # type: (str) -> Node
     # they are also destroyed. But we don't care for
     # removed-but-not-destroyed nodes
     return Node(mobj)
+
+
+def find(path, default=None):
+    """Find node at `path` or return `default`"""
+    try:
+        return encode(path)
+    except ExistError:
+        return default
 
 
 def fromHash(code, default=None):
@@ -5341,7 +5371,19 @@ class _BaseModifier(object):
                 # Make our commit within the current undo chunk,
                 # but *before* we call any maya.cmds as it may
                 # otherwise confuse the chunk
-                commit(self._modifier.undoIt, self._modifier.doIt)
+                def undoit():
+                    for change in self._animChanges:
+                        change.undoIt()
+
+                    self._modifier.undoIt()
+
+                def redoit():
+                    self._modifier.doIt()
+
+                    for change in self._animChanges:
+                        change.redoIt()
+
+                commit(undoit, redoit)
 
             # These all involve calling on cmds,
             # which manages undo on its own.
@@ -5381,6 +5423,7 @@ class _BaseModifier(object):
         self._lockAttrs = []
         self._keyableAttrs = []
         self._niceNames = []
+        self._animChanges = []
 
         # Undo
         self._doneLockAttrs = []
@@ -5772,7 +5815,10 @@ class _BaseModifier(object):
         if isinstance(value, om.MPlug):
             value = Plug(value.node(), value).read()
 
-        _python_to_mod(value, plug, self._modifier)
+        result = _python_to_mod(value, plug, self._modifier)
+
+        if isinstance(result, oma.MAnimCurveChange):
+            self._animChanges += [result]
 
         if SAFE_MODE:
             self._modifier.doIt()

--- a/cmdx.py
+++ b/cmdx.py
@@ -19,7 +19,7 @@ from maya import cmds
 from maya.api import OpenMaya as om, OpenMayaAnim as oma, OpenMayaUI as omui
 from maya import OpenMaya as om1, OpenMayaMPx as ompx1, OpenMayaUI as omui1
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 PY3 = sys.version_info[0] == 3
 

--- a/cmdx.py
+++ b/cmdx.py
@@ -124,7 +124,7 @@ GlobalDependencyNode = om.MFnDependencyNode()
 First = 0
 Last = -1
 
-# Animation curve interpolation, from MFnAnimCurve::TangentType
+# Animation curve tangents, from MFnAnimCurve::TangentType
 Stepped = 5
 Linear = 2
 Smooth = 4
@@ -839,6 +839,7 @@ class Node(object):
             True
 
         """
+
         if isinstance(type, om.MTypeId):
             return type == self._fn.typeId
         elif isinstance(type, string_types):
@@ -847,7 +848,9 @@ class Node(object):
             return any(self.isA(t) for t in type)
         elif isinstance(type, int):
             return self._mobject.hasFn(type)
+
         cmds.warning("Unsupported argument passed to isA('%s')" % type)
+
         return False
 
     def lock(self, value=True):
@@ -1271,6 +1274,7 @@ class Node(object):
                                                plugs=plugs,
                                                source=source,
                                                destination=destination):
+
                 if connections:
                     yield connection, plug if plugs else self
                 else:
@@ -2284,7 +2288,7 @@ class AnimCurve(Node):
             super(AnimCurve, self).__init__(mobj, exists)
             self._fna = oma.MFnAnimCurve(mobj)
 
-        def key(self, time, value, interpolation=Linear):
+        def key(self, time, value, tangents=Linear):
             if isinstance(time, (float, int)):
                 time = Seconds(time)
 
@@ -2293,21 +2297,24 @@ class AnimCurve(Node):
             if index:
                 self._fna.setValue(index, value)
             else:
-                self._fna.addKey(time, value, interpolation, interpolation)
+                self._fna.addKey(time, value, tangents, tangents)
 
-        def keys(self, times, values, interpolation=Linear, change=None):
+        def keys(self, times, values, tangents=None, change=None):
             times = list(map(
                 lambda t: Seconds(t) if isinstance(t, (float, int)) else t,
                 times
             ))
+
+            if tangents is None:
+                tangents = oma.MFnAnimCurve.kTangentGlobal
 
             try:
                 keepExistingKeys = False  # Default
                 args = [
                     times,
                     values,
-                    oma.MFnAnimCurve.kTangentGlobal,
-                    oma.MFnAnimCurve.kTangentGlobal,
+                    tangents,
+                    tangents,
                     keepExistingKeys,
                 ]
 
@@ -3714,7 +3721,7 @@ class Plug(object):
             raise
 
     if __maya_version__ > 2015:
-        def animate(self, values, interpolation=None):
+        def animate(self, values, tangents=None):
             """Treat values as time:value pairs and animate this attribute
 
             Example:
@@ -3741,7 +3748,7 @@ class Plug(object):
                 anim = createNode(typ)
                 anim["output"] >> self
 
-            anim.keys(times, values, interpolation=Linear)
+            anim.keys(times, values, tangents=Linear)
 
     def write(self, value):
         if isinstance(value, dict) and __maya_version__ > 2015:
@@ -3847,6 +3854,21 @@ class Plug(object):
 
         """
 
+        def _name(plug):
+            return plug.partialName(
+                False,  # includeNodeName
+                False,  # includeNonMandatoryIndices
+                False,  # includeInstancedIndices
+                False,  # useAlias
+                False,  # useFullAttributePath
+                True    # useLongNames
+            )
+
+        plug_names = []
+        if isinstance(plugs, (list, tuple)):
+            plug_names = plugs
+            plugs = True
+
         for plug in self._mplug.connectedTo(source, destination):
             mobject = plug.node()
             node = Node(mobject)
@@ -3882,6 +3904,9 @@ class Plug(object):
                         else:
                             plug = node.findPlug(plug.partialName())
 
+                    if plug_names and _name(plug) not in plug_names:
+                        continue
+
                     yield Plug(node, plug, unit)
                 else:
                     yield node
@@ -3893,6 +3918,10 @@ class Plug(object):
                    plug=False,
                    unit=None):
         """Return first connection from :func:`connections()`"""
+
+        if isinstance(plug, string_types):
+            plug = (plug,)
+
         return next(self.connections(type=type,
                                      source=source,
                                      destination=destination,
@@ -3904,11 +3933,11 @@ class Plug(object):
               plug=False,
               unit=None):
         """Return input connection from :func:`connections()`"""
-        return next(self.connections(type=type,
-                                     source=True,
-                                     destination=False,
-                                     plugs=plug,
-                                     unit=unit), None)
+        return self.connection(type=type,
+                               source=True,
+                               destination=False,
+                               plug=plug,
+                               unit=unit)
 
     def outputs(self,
                 type=None,
@@ -3926,11 +3955,11 @@ class Plug(object):
                plug=False,
                unit=None):
         """Return first output connection from :func:`connections()`"""
-        return next(self.connections(type=type,
-                                     source=False,
-                                     destination=True,
-                                     plugs=plug,
-                                     unit=unit), None)
+        return self.connection(type=type,
+                               source=False,
+                               destination=True,
+                               plug=plug,
+                               unit=unit)
 
     def source(self, unit=None):
         cls = self.__class__
@@ -4089,29 +4118,41 @@ class TransformationMatrix(om.MTransformationMatrix):
         space = space or sTransform
         return Vector(super(TransformationMatrix, self).rotatePivot(space))
 
+    def rotatePivotTranslation(self, space=sTransform):
+        """This method does not typically support optional arguments"""
+        return Vector(
+            super(TransformationMatrix, self).rotatePivotTranslation(space)
+        )
+
+    def scalePivot(self, space=sTransform):
+        """This method does not typically support optional arguments"""
+        return Vector(super(TransformationMatrix, self).scalePivot(space))
+
+    def scalePivotTranslation(self, space=sTransform):
+        """This method does not typically support optional arguments"""
+        return Vector(
+            super(TransformationMatrix, self).scalePivotTranslation(space)
+        )
+
     def setRotatePivot(self, pivot, space=sTransform, balance=False):
         pivot = pivot if isinstance(pivot, om.MPoint) else om.MPoint(pivot)
         return super(TransformationMatrix, self).setRotatePivot(
             pivot, space, balance)
 
-    def rotatePivotTranslation(self, space=None):
-        """This method does not typically support optional arguments"""
-        space = space or sTransform
-        return Vector(
-            super(TransformationMatrix, self).rotatePivotTranslation(space)
-        )
+    def setRotatePivotTranslation(self, pivot, space=sTransform):
+        pivot = pivot if isinstance(pivot, om.MVector) else om.MVector(pivot)
+        return super(TransformationMatrix, self).setRotatePivotTranslation(
+            pivot, space)
 
-    def scalePivot(self, space=None):
-        """This method does not typically support optional arguments"""
-        space = space or sTransform
-        return Vector(super(TransformationMatrix, self).scalePivot(space))
+    def setScalePivot(self, pivot, space=sTransform, balance=False):
+        pivot = pivot if isinstance(pivot, om.MPoint) else om.MPoint(pivot)
+        return super(TransformationMatrix, self).setScalePivot(
+            pivot, space, balance)
 
-    def scalePivotTranslation(self, space=None):
-        """This method does not typically support optional arguments"""
-        space = space or sTransform
-        return Vector(
-            super(TransformationMatrix, self).scalePivotTranslation(space)
-        )
+    def setScalePivotTranslation(self, pivot, space=sTransform):
+        pivot = pivot if isinstance(pivot, om.MVector) else om.MVector(pivot)
+        return super(TransformationMatrix, self).setScalePivotTranslation(
+            pivot, space)
 
     def translation(self, space=None):  # type: (om.MSpace) -> om.MVector
         """This method does not typically support optional arguments"""
@@ -4940,6 +4981,8 @@ def _python_to_mod(value, plug, mod):
 
     """
 
+    assert isinstance(plug, Plug), "plug must be of type cmdx.Plug"
+
     if isinstance(value, dict) and __maya_version__ > 2015:
         times, values = map(UiUnit(), value.keys()), value.values()
         curve_typ = _find_curve_type(plug)
@@ -4955,8 +4998,16 @@ def _python_to_mod(value, plug, mod):
 
             mod.connect(curve["output"]._mplug, plug._mplug)
 
+        tangents = None
+
+        # Unit can also be Time and other unrelated types
+        if plug._unit in (Stepped, Linear, Smooth):
+            tangents = plug._unit
+
         change = oma.MAnimCurveChange()
-        curve.keys(times, values, change=change)
+        curve.keys(times, values,
+                   tangents=tangents,
+                   change=change)
 
         return change
 
@@ -5670,10 +5721,17 @@ class _BaseModifier(object):
 
         """
 
+        mobj = node
+        if isinstance(node, Node):
+            mobj = node._mobject
+
+        assert isinstance(mobj, om.MObject), (
+            "%s was not an MObject" % node
+        )
+
         # This is one picky s-o-b, let's not give it the
         # satisfaction of ever erroring out on us. Performance
         # is of less importance here, as deletion is not time-cricital
-        mobj = node._mobject
         if not _isalive(mobj):
             raise ExistError
 
@@ -5685,10 +5743,13 @@ class _BaseModifier(object):
 
     @record_history
     def renameNode(self, node, name):
-        if SAFE_MODE:
-            assert _isalive(node._mobject)
+        if isinstance(node, Node):
+            node = node._mobject
 
-        return self._modifier.renameNode(node._mobject, name)
+        if SAFE_MODE:
+            assert _isalive(node)
+
+        return self._modifier.renameNode(node, name)
 
     @record_history
     def addAttr(self, node, attr):
@@ -6268,6 +6329,7 @@ class _BaseModifier(object):
     rename = renameNode
 
     if ENABLE_PEP8:
+        commit = doIt
         do_it = doIt
         undo_it = undoIt
         create_node = createNode
@@ -6280,6 +6342,7 @@ class _BaseModifier(object):
         smart_set_attr = smartSetAttr
         delete_attr = deleteAttr
         reset_attr = resetAttr
+        lock_attr = setLocked
         try_connect = tryConnect
         connect_attr = connectAttr
         connect_attrs = connectAttrs
@@ -6436,13 +6499,35 @@ def currentTime(time=None):
     if time is None:
         return oma.MAnimControl.currentTime()
     else:
+        if not isinstance(time, om.MTime):
+            time = om.MTime(time, TimeUiUnit())
+
         return oma.MAnimControl.setCurrentTime(time)
+
+
+def selectedTime():
+    """Return currently selected time range in MTime format"""
+    from maya import mel
+
+    try:
+        control = mel.eval('$tmpVar=$gPlayBackSlider')
+        time_range = cmds.timeControl(control, q=True, rangeArray=True)
+        time_range = list(om.MTime(t, TimeUiUnit()) for t in time_range)
+
+    except RuntimeError:
+        # Only relevant in interactive mode
+        return (minTime(), minTime() + 1)
+
+    return time_range
 
 
 def animationStartTime(time=None):
     if time is None:
         return oma.MAnimControl.animationStartTime()
     else:
+        if not isinstance(time, om.MTime):
+            time = om.MTime(time, TimeUiUnit())
+
         return oma.MAnimControl.setAnimationStartTime(time)
 
 
@@ -6450,6 +6535,9 @@ def animationEndTime(time=None):
     if time is None:
         return oma.MAnimControl.animationEndTime()
     else:
+        if not isinstance(time, om.MTime):
+            time = om.MTime(time, TimeUiUnit())
+
         return oma.MAnimControl.setAnimationEndTime(time)
 
 
@@ -6457,6 +6545,9 @@ def minTime(time=None):
     if time is None:
         return oma.MAnimControl.minTime()
     else:
+        if not isinstance(time, om.MTime):
+            time = om.MTime(time, TimeUiUnit())
+
         return oma.MAnimControl.setMinTime(time)
 
 
@@ -6464,6 +6555,9 @@ def maxTime(time=None):
     if time is None:
         return oma.MAnimControl.maxTime()
     else:
+        if not isinstance(time, om.MTime):
+            time = om.MTime(time, TimeUiUnit())
+
         return oma.MAnimControl.setMaxTime(time)
 
 
@@ -6896,6 +6990,7 @@ if ENABLE_PEP8:
     max_time = maxTime
     animation_start_time = animationStartTime
     animation_end_time = animationEndTime
+    selected_time = selectedTime
     up_axis = upAxis
     set_up_axis = setUpAxis
 
@@ -6945,7 +7040,7 @@ def editCurve(parent, points, degree=1, form=kOpen):
     return encode(shapeFn.fullPathName())
 
 
-def curve(parent, points, degree=1, form=kOpen):
+def curve(parent, points, degree=1, form=kOpen, mod=None):
     """Create a NURBS curve from a series of points
 
     Arguments:
@@ -6953,6 +7048,7 @@ def curve(parent, points, degree=1, form=kOpen):
         points (list): One tuples per point, with 3 floats each
         degree (int, optional): Degree of curve, 1 is linear
         form (int, optional): Whether to close the curve or not
+        mod (DagModifier, optional): Use this for undo/redo
 
     Example:
         >>> parent = createNode("transform")
@@ -6969,47 +7065,40 @@ def curve(parent, points, degree=1, form=kOpen):
         "parent must be of type cmdx.DagNode"
     )
 
-    # Superimpose end knots
-    # startpoints = [points[0]] * (degree - 1)
-    # endpoints = [points[-1]] * (degree - 1)
-    # points = startpoints + list(points) + endpoints
-
     degree = min(3, max(1, degree))
-
-    cvs = om1.MPointArray()
-    knots = om1.MDoubleArray()
-    curveFn = om1.MFnNurbsCurve()
 
     knotcount = len(points) - degree + 2 * degree - 1
 
-    for point in points:
-        cvs.append(om1.MPoint(*point))
+    cvs = [p for p in points]
+    knots = [i for i in range(knotcount)]
 
-    for index in range(knotcount):
-        knots.append(index)
-
+    curveFn = om.MFnNurbsCurve()
     mobj = curveFn.create(cvs,
                           knots,
                           degree,
                           form,
                           False,
                           True,
-                          _encode1(parent.path()))
+                          parent.object())
 
-    mod = om1.MDagModifier()
-    mod.renameNode(mobj, parent.name(namespace=True) + "Shape")
-    mod.doIt()
+    if mod:
+        mod.rename(mobj, parent.name(namespace=True) + "Shape")
 
-    def undo():
-        mod.deleteNode(mobj)
+    else:
+        mod = DagModifier()
+        mod.rename(mobj, parent.name(namespace=True) + "Shape")
         mod.doIt()
 
-    def redo():
-        mod.undoIt()
+        def undo():
+            mod.deleteNode(mobj)
+            mod.doIt()
 
-    commit(undo, redo)
+        def redo():
+            mod.undoIt()
 
-    shapeFn = om1.MFnDagNode(mobj)
+        commit(undo, redo)
+
+    shapeFn = om.MFnDagNode(mobj)
     return encode(shapeFn.fullPathName())
 
 
@@ -7018,12 +7107,12 @@ def lookAt(origin, center, up=None):
 
     See glm::glc::matrix_transform::lookAt for reference
 
-             + Z (up)
-            /
-           /
+                + Z (up)
+               /
+              /
     (origin) o------ + X (center)
-           \
-            + Y
+              \
+               + Y
 
     Arguments:
         origin (Vector): Starting position
@@ -7058,10 +7147,10 @@ def lookAt(origin, center, up=None):
     z = x ^ y
 
     return MatrixType((
-        x[0], x[1], x[2], 0,
-        y[0], y[1], y[2], 0,
-        z[0], z[1], z[2], 0,
-        0, 0, 0, 0
+        x[0], x[1], x[2], 1,
+        y[0], y[1], y[2], 1,
+        z[0], z[1], z[2], 1,
+        0, 0, 0, 1
     ))
 
 


### PR DESCRIPTION
Added support for undoable animation.

```py
with cmdx.DagModifier() as mod:
  node = mod.create_node("transform", name="animatedNode")

# Set some keys
with cmdx.DagModifier() as mod:
  mod.set_attr(node["tx"], {1: 0.0, 5: 2.0, 10: 0.0 })

# Set some more keys
with cmdx.DagModifier() as mod:
  mod.set_attr(node["tx"], {20: 0.0, 25: 2.0, 30: 0.0 })

cmds.undo()  # Keys 2 bye-bye
cmds.undo()  # Keys 1 bye-bye
cmds.undo()  # Node bye-bye
```

Notice that it boths creates the (correct!) animation curve node (linear for translation, angular for rotation, for example), depending on the plug type, or edits it if one already exists.

And more:

- Support for tangents and AnimCurve
- `AnimCurve.key(interpolation)` was renamed `tangents`
- Support for `plug.connection(plugs=("name1", "name2")` to match by name
- Add `Tm.setRotatePivot` and `setRotatePivotTranslate`
- Add` Tm.setScalePivot` and `setScaleivotTranslate`
- Add cmdx.time() and cmdx.frame() conversion functions, like math.degrees() and math.radians()
- Support matching array-plugs by name
- Repair cmdx.lookAt()