### PR TITLE
first pass of keying a plug with pair blend or anim layer

### DIFF
--- a/cmdx.py
+++ b/cmdx.py
@@ -5150,12 +5150,19 @@ def _python_to_mod(value, plug, mod):
         >>> int(node["ty"].read())
         10
 
+        # Support for animation keys
+        >>> mod.set_attr(node["ty"], {1: 0.0, 5: 2.0, 10: 0.0})
+        >>> mod.doIt()
+        >>> int(node["ty"].read(time=UiUnit()(5)))
+        2
+
     """
 
     assert isinstance(plug, Plug), "plug must be of type cmdx.Plug"
 
     if isinstance(value, dict) and __maya_version__ > 2015:
-        times, values = map(UiUnit(), value.keys()), value.values()
+        times, values = list(map(UiUnit(), value.keys())), value.values()
+        plug = plug.findAnimatedPlug()
         curve_typ = _find_curve_type(plug)
         curve = plug.input(type=curve_typ)
 

--- a/cmdx.py
+++ b/cmdx.py
@@ -133,19 +133,19 @@ Smooth = 4
 # Animation blend nodes
 # Because type checking against MFn.kBlendNodeBase doesn't work :(
 AnimBlendTypes = (
-    om.MTypeId(0x41424e41), # AnimBlendNodeAdditive
-    om.MTypeId(0x41424141), # AnimBlendNodeAdditiveDA
-    om.MTypeId(0x4142414c), # AnimBlendNodeAdditiveDL
-    om.MTypeId(0x41424146), # AnimBlendNodeAdditiveF
-    om.MTypeId(0x41424641), # AnimBlendNodeAdditiveFA
-    om.MTypeId(0x4142464c), # AnimBlendNodeAdditiveFL
-    om.MTypeId(0x41424153), # AnimBlendNodeAdditiveI16
-    om.MTypeId(0x41424149), # AnimBlendNodeAdditiveI32
-    om.MTypeId(0x41424e52), # AnimBlendNodeAdditiveRotation
-    om.MTypeId(0x41424e53), # AnimBlendNodeAdditiveScale
-    om.MTypeId(0x4142424f), # AnimBlendNodeBoolean
-    om.MTypeId(0x41424e45), # AnimBlendNodeEnum
-    om.MTypeId(0x41425449), # AnimBlendNodeTime
+    om.MFn.kBlendNodeAdditiveRotation,
+    om.MFn.kBlendNodeAdditiveScale,
+    om.MFn.kBlendNodeBoolean,
+    om.MFn.kBlendNodeDouble,
+    om.MFn.kBlendNodeDoubleAngle,
+    om.MFn.kBlendNodeDoubleLinear,
+    om.MFn.kBlendNodeEnum,
+    om.MFn.kBlendNodeFloat,
+    om.MFn.kBlendNodeFloatAngle,
+    om.MFn.kBlendNodeFloatLinear,
+    om.MFn.kBlendNodeInt16,
+    om.MFn.kBlendNodeInt32,
+    om.MFn.kBlendNodeTime,
 )
 
 history = dict()

--- a/cmdx.py
+++ b/cmdx.py
@@ -3250,7 +3250,7 @@ class Plug(object):
         Example:
             >>> _new()
             >>> node = createNode("transform")
-            >>> node["tx"].findAnimatedPlug().plug() == node["tx"].plug()
+            >>> node["tx"].findAnimatedPlug().path() == node["tx"].path()
             True
 
             # Constraint
@@ -3258,16 +3258,16 @@ class Plug(object):
             >>> parent = createNode("transform")
             >>> _ = cmds.parentConstraint(str(parent), str(node))
             >>> blend = ls(type="pairBlend")[0]
-            >>> node["tx"].findAnimatedPlug().plug() == blend["inTranslateX1"].plug()
+            >>> node["tx"].findAnimatedPlug().path() == blend["inTranslateX1"].path()
             True
 
             # Animation layers
             >>> layer = encode(cmds.animLayer(at=node["tx"].path()))
-            >>> node["tx"].findAnimatedPlug().plug() == blend["inTranslateX1"].plug()
+            >>> node["tx"].findAnimatedPlug().path() == blend["inTranslateX1"].path()
             True
             >>> cmds.animLayer(str(layer), e=True, preferred=True)
             >>> animBlend = ls(type="animBlendNodeBase")[0]
-            >>> node["tx"].findAnimatedPlug().plug() == animBlend["inputB"].plug()
+            >>> node["tx"].findAnimatedPlug().path() == animBlend["inputB"].path()
             True
 
             # Animation layer then constraint
@@ -3277,10 +3277,10 @@ class Plug(object):
             >>> parent = createNode("transform")
             >>> _ = cmds.parentConstraint(str(parent), str(node))
             >>> animBlend = ls(type="animBlendNodeBase")[0]
-            >>> node["tx"].findAnimatedPlug().plug() == animBlend["inputA"].plug()
+            >>> node["tx"].findAnimatedPlug().path() == animBlend["inputA"].path()
             True
             >>> cmds.animLayer(str(layer), e=True, preferred=True)
-            >>> node["tx"].findAnimatedPlug().plug() == animBlend["inputB"].plug()
+            >>> node["tx"].findAnimatedPlug().path() == animBlend["inputB"].path()
             True
 
         """
@@ -5153,7 +5153,7 @@ def _python_to_mod(value, plug, mod):
         # Support for animation keys
         >>> mod.set_attr(node["ty"], {1: 0.0, 5: 2.0, 10: 0.0})
         >>> mod.doIt()
-        >>> int(node["ty"].read(time=UiUnit()(5)))
+        >>> int(node["ty"].read(time=time(5)))
         2
 
     """
@@ -5161,7 +5161,7 @@ def _python_to_mod(value, plug, mod):
     assert isinstance(plug, Plug), "plug must be of type cmdx.Plug"
 
     if isinstance(value, dict) and __maya_version__ > 2015:
-        times, values = list(map(UiUnit(), value.keys())), value.values()
+        times, values = list(map(time, value.keys())), value.values()
         plug = plug.findAnimatedPlug()
         curve_typ = _find_curve_type(plug)
         curve = plug.input(type=curve_typ)

--- a/cmdx.py
+++ b/cmdx.py
@@ -133,19 +133,19 @@ Smooth = 4
 # Animation blend nodes
 # Because type checking against MFn.kBlendNodeBase doesn't work :(
 AnimBlendTypes = (
-    om.MTypeId(0x41424e41),
-    om.MTypeId(0x41424141),
-    om.MTypeId(0x4142414c),
-    om.MTypeId(0x41424146),
-    om.MTypeId(0x41424641),
-    om.MTypeId(0x4142464c),
-    om.MTypeId(0x41424153),
-    om.MTypeId(0x41424149),
-    om.MTypeId(0x41424e52),
-    om.MTypeId(0x41424e53),
-    om.MTypeId(0x4142424f),
-    om.MTypeId(0x41424e45),
-    om.MTypeId(0x41425449)
+    om.MTypeId(0x41424e41), # AnimBlendNodeAdditive
+    om.MTypeId(0x41424141), # AnimBlendNodeAdditiveDA
+    om.MTypeId(0x4142414c), # AnimBlendNodeAdditiveDL
+    om.MTypeId(0x41424146), # AnimBlendNodeAdditiveF
+    om.MTypeId(0x41424641), # AnimBlendNodeAdditiveFA
+    om.MTypeId(0x4142464c), # AnimBlendNodeAdditiveFL
+    om.MTypeId(0x41424153), # AnimBlendNodeAdditiveI16
+    om.MTypeId(0x41424149), # AnimBlendNodeAdditiveI32
+    om.MTypeId(0x41424e52), # AnimBlendNodeAdditiveRotation
+    om.MTypeId(0x41424e53), # AnimBlendNodeAdditiveScale
+    om.MTypeId(0x4142424f), # AnimBlendNodeBoolean
+    om.MTypeId(0x41424e45), # AnimBlendNodeEnum
+    om.MTypeId(0x41425449), # AnimBlendNodeTime
 )
 
 history = dict()
@@ -4158,6 +4158,7 @@ class Plug(object):
         array_indices = arrayIndices
         type_class = typeClass
         next_available_index = nextAvailableIndex
+        find_animated_plug = findAnimatedPlug
 
 
 class TransformationMatrix(om.MTransformationMatrix):


### PR DESCRIPTION
First pass fix of #59 

This should work with plugs in animation layers too (it walks the connections to find the correct plug to apply animation to).

Couple of caveats:

- If the plug is constrained but doesn't already have a pairBlend it will just disconnect and replace the constraint.
- I had to add a bunch of animBlend types to a tuple at the top of the file because for some reason type checking against MFn.kBlendNodeBase doesn't seem to work? Maybe you know how to solve?

I also wanted to ask about how setting an attribute with a dictionary should work. Currently if you have animation on an attribute and you assign a dict it will add to the keys:

```python
# node["tx"] has a key on frame 0 and 5
node["tx"] = {10: 5, 15: -5}
# node["tx"] now has keys on 0, 5, 10, and 15
```
I was wondering if it would make more sense for that operation to wipe all the keys and then instead we could put that adding functionality on the `+=` operator instead.

Thanks 😄 
