### PR TITLE
Makes listRelatives behave more like Maya cmds

### DIFF
--- a/cmdx.py
+++ b/cmdx.py
@@ -7239,10 +7239,7 @@ def listRelatives(node,
     if not isinstance(node, DagNode):
         return None
 
-    if shapes and parent:
-        return []
-
-    if shapes:
+    if shapes and not parent:
         return list(node.shapes(type=type))
 
     if parent:

--- a/cmdx.py
+++ b/cmdx.py
@@ -13,6 +13,7 @@ import traceback
 import collections
 import contextlib
 from functools import wraps
+from itertools import chain
 
 from maya import cmds
 from maya.api import OpenMaya as om, OpenMayaAnim as oma, OpenMayaUI as omui
@@ -7238,16 +7239,20 @@ def listRelatives(node,
     if not isinstance(node, DagNode):
         return None
 
-    elif allDescendents:
-        return list(node.descendents(type=type))
-    elif shapes:
+    if shapes and parent:
+        return []
+
+    if shapes:
         return list(node.shapes(type=type))
 
-    elif parent:
-        return [node.parent(type=type)]
+    if parent:
+        _parent = node.parent(type=type)
+        return [_parent] if _parent else []
 
-    elif children:
-        return list(node.children(type=type))
+    if allDescendents:
+        return list(node.descendents(type=type))
+
+    return list(chain(node.shapes(type=type), node.children(type=type)))
 
 
 def listConnections(attr):

--- a/tests.py
+++ b/tests.py
@@ -609,3 +609,57 @@ def test_commit_undo():
 
 def test_modifier_redo():
     pass
+
+
+def _setup_listrelatives_test():
+    new_scene()
+    cmds.createNode('transform', name='topGrp')
+    cmds.polyCube(name='hierarchyCube', constructionHistory=False)
+    cmds.parent('hierarchyCube', 'topGrp')
+    cmds.createNode('transform', name='botGrp', parent='hierarchyCube')
+    cmds.polyCube(name='worldCube', constructionHistory=False)
+    cmds.blendShape('hierarchyCube', 'worldCube', name='cubeBlend')
+
+
+@with_setup(_setup_listrelatives_test)
+def test_listrelatives_children():
+
+    result_cmdx = cmdx.listRelatives('hierarchyCube', children=True)
+    result_cmdx = [i.name() for i in result_cmdx]
+    result_cmds = cmds.listRelatives('hierarchyCube', children=True)
+
+    assert_equals(result_cmdx, result_cmds)
+
+
+@with_setup(_setup_listrelatives_test)
+def test_listrelatives_alldescendents():
+
+    result_cmdx = cmdx.listRelatives('topGrp', allDescendents=True)
+    result_cmdx = [i.name() for i in result_cmdx]
+    result_cmds = cmds.listRelatives('topGrp', allDescendents=True)
+
+    # cmds has a special result order, so compare sets
+    result_cmdx = set(result_cmdx)
+    result_cmds = set(result_cmds)
+
+    assert_equals(result_cmdx, result_cmds)
+
+
+@with_setup(_setup_listrelatives_test)
+def test_listrelatives_parent():
+
+    result_cmdx = cmdx.listRelatives('hierarchyCubeShape', parent=True)
+    result_cmdx = [i.name() for i in result_cmdx]
+    result_cmds = cmds.listRelatives('hierarchyCubeShape', parent=True)
+
+    assert_equals(result_cmdx, result_cmds)
+
+
+@with_setup(_setup_listrelatives_test)
+def test_listrelatives_shapes():
+
+    result_cmdx = cmdx.listRelatives('worldCube', shapes=True)
+    result_cmdx = [i.name() for i in result_cmdx]
+    result_cmds = cmds.listRelatives('worldCube', shapes=True)
+
+    assert_equals(result_cmdx, result_cmds)


### PR DESCRIPTION
## Description of Changes

Potential solution for #20

I changed up the order of the if statements so that the cmdx behaves like the cmds. Some of the behavior is not necessarily to my liking, but it is how cmds work. You will see what I mean in the testing section below. Perhaps a happy medium between both versions would be the best option? Depends on preference I guess.

Another small change I did from the previous behavior was to have the parent return value be an empty list if None, instead of a list with a None: `[None]`.

## Testing Done

Using the following setup:
```python
import cmdx
from maya import cmds
from itertools import product

cmds.file(new=True, force=True)

cmds.createNode('transform', name='topGrp')
cmds.polyCube(name='hierarchyCube', constructionHistory=False)
cmds.parent('hierarchyCube', 'topGrp')
cmds.createNode('transform', name='botGrp', parent='hierarchyCube')
cmds.polyCube(name='worldCube', constructionHistory=False)
```
I ran the following, to test all possible kwargs combination with both versions and have it raise a RuntimeError if the result wasn't the same.
```python
nodes = ('topGrp', 'worldCube')
args = ('children', 'allDescendents', 'parent', 'shapes')
vals = (True, False)
vals_product = product(vals, vals, vals, vals)

for node, vals_tuple in product(nodes, vals_product):
    val_a, val_b, val_c, val_d = vals_tuple
    kwargs = {args[0]: val_a, args[1]: val_b, args[2]: val_c, args[3]: val_d}
    cmds_result = cmds.listRelatives(node, **kwargs) or []
    cmdx_result = [str(i).split('|')[-1] for i in cmdx.listRelatives(node, **kwargs)]
    # Order is different, maybe something to look into in the future
    if set(cmds_result) != set(cmdx_result):
        print(kwargs)
        raise RuntimeError(f'cmds: {cmds_result}, cmdx: {cmdx_result}')
```

Which raised no `RuntimeErrors`

### Test notes
- I extracted the node name from its fullPath string using `split`, as a way to keep the current `__repr__` behavior of the Nodes and not have that affect the testing. Also, as stated in the code snippet, the returning lists have different orders form the cmds, which I also chose to ignore for the testing.
- Some of the cmds results are a bit misleading, but I aimed to match it regardless, for consistency sake.
    Examples:
    ```python
    cmds.listRelatives('topGrp', children=False)
    # Result: ['hierarchyCube'] # 
    cmdx.listRelatives('topGrp', children=False)
    # Result: [|topGrp|hierarchyCube] #
    ```
    ```python
    cmds.listRelatives('worldCube', shapes=False)
    # Result: ['worldCubeShape'] # 
    cmdx.listRelatives('worldCube', shapes=False)
    # Result: [|worldCube|worldCubeShape] #
    ````
- It turns out the `children` kwarg is not used with this setup. But, I left it there for now since removing it seemed like a bad idea.

