### PR TITLE
Implements a different approach for __repr__

### DIFF
--- a/cmdx.py
+++ b/cmdx.py
@@ -2674,20 +2674,27 @@ class Plug(object):
         return str(self.read())
 
     def __repr__(self):
-        cls_name = '{}.{}'.format(__name__, self.__class__.__name__)
-        if self._mplug.attribute().apiType() == om.MFn.kCompoundAttribute:
-            return '{}("{}", "{}")'.format(cls_name,
-                                           self.node().name(),
-                                           self.name())
-        read_val = self.read()
-        if isinstance(read_val, string_types):
-            # Add surrounding single quotes, indicating the value is a string
-            read_val = '"{}"'.format(read_val)
+        try:
+            # Delegate the value reading to __str__
+            read_result = str(self)
+            valid = True
+        except:
+            valid = False
 
-        return '{}("{}", "{}") == {}'.format(cls_name,
-                                             self.node().name(),
-                                             self.name(),
-                                             read_val)
+        cls_name = '{}.{}'.format(__name__, self.__class__.__name__)
+        msg = '{}("{}", "{}")'.format(cls_name,
+                                      self.node().name(),
+                                      self.name())
+        if valid:
+            try:
+                if self.typeClass() == String:
+                    # Add surrounding quotes, indicating it is a string
+                    read_result = '"{}"'.format(read_result)
+            except TypeError:
+                pass
+            msg += ' == {}'.format(read_result)
+
+        return msg
 
     def __rshift__(self, other):
         """Support connecting attributes via A >> B"""

--- a/cmdx.py
+++ b/cmdx.py
@@ -511,6 +511,8 @@ class Node(object):
         >>> transform = createNode("transform")
         >>> transform["tx"] = 5
         >>> transform["worldMatrix"][0] >> decompose["inputMatrix"]
+        >>> decompose["outputTranslate"]
+        <cmdx.Plug : (5.0, 0.0, 0.0)>
         >>> decompose["outputTranslate"].read()
         (5.0, 0.0, 0.0)
 
@@ -579,6 +581,8 @@ class Node(object):
         Example:
             >>> node = createNode("transform")
             >>> node["translate"] = (1, 1, 1)
+            >>> node["translate", Meters]
+            <cmdx.Plug : (0.01, 0.01, 0.01)>
             >>> node["translate", Meters].read()
             (0.01, 0.01, 0.01)
 
@@ -625,6 +629,8 @@ class Node(object):
             True
             >>> node["rotateX", Degrees] = 1.0
             >>> node["rotateX"] = Degrees(1)
+            >>> node["rotateX", Degrees]
+            <cmdx.Plug : 1.0>
             >>> node["rotateX", Degrees].read()
             1.0
             >>> node["myDist"] = Distance()
@@ -981,6 +987,8 @@ class Node(object):
         Examples:
             >>> node = createNode("transform")
             >>> node.update({"tx": 5.0, ("ry", Degrees): 30.0})
+            >>> node["tx"]
+            <cmdx.Plug : 5.0>
             >>> node["tx"].read()
             5.0
 
@@ -999,13 +1007,19 @@ class Node(object):
         Example:
             >>> node = createNode("transform")
             >>> node["translateX"] = 5
+            >>> node["translateX"]
+            <cmdx.Plug : 5.0>
             >>> node["translateX"].read()
             5.0
             >>> # Plug was reused
+            >>> node["translateX"]
+            <cmdx.Plug : 5.0>
             >>> node["translateX"].read()
             5.0
             >>> # Value was reused
             >>> node.clear()
+            >>> node["translateX"]
+            <cmdx.Plug : 5.0>
             >>> node["translateX"].read()
             5.0
             >>> # Plug and value was recomputed
@@ -1524,8 +1538,9 @@ class DagNode(Node):
             >>> _new()
             >>> parent = createNode("transform", "parent")
             >>> child =  createNode("transform", "child", parent)
-            >>> result = (parent | "child").path()
-            >>> result in (
+            >>> parent | "child"
+            <cmdx.DagNode : '|parent|child'>
+            >>> (parent | "child").path() in (
             ...    '|parent|child',
             ...   u'|parent|child'
             ... )
@@ -1533,8 +1548,9 @@ class DagNode(Node):
 
             # Stackable too
             >>> grand =  createNode("transform", "grand", child)
-            >>> result = (parent | "child" | "grand").path()
-            >>> result in (
+            >>> parent | "child" | "grand"
+            <cmdx.DagNode : '|parent|child|grand'>
+            >>> (parent | "child" | "grand").path() in (
             ...    '|parent|child|grand',
             ...   u'|parent|child|grand'
             ... )
@@ -2301,22 +2317,24 @@ class ObjectSet(Node):
         """Return members, converting nested object sets into its members
 
         Example:
-            >>> from maya import cmds
-            >>> _ = cmds.file(new=True, force=True)
-            >>> a = cmds.createNode("transform", name="a")
-            >>> b = cmds.createNode("transform", name="b")
-            >>> c = cmds.createNode("transform", name="c")
-            >>> cmds.select(a)
-            >>> gc = cmds.sets([a], name="grandchild")
-            >>> cc = cmds.sets([gc, b], name="child")
-            >>> parent = cmds.sets([cc, c], name="parent")
-            >>> mainset = encode(parent)
-            >>> result = sorted([n.path() for n in mainset.flatten()])
-            >>> result in (
-            ...    ['|a', '|b', '|c'],
-            ...    [u'|a', u'|b', u'|c']
-            ... )
-            True
+          >>> from maya import cmds
+          >>> _ = cmds.file(new=True, force=True)
+          >>> a = cmds.createNode("transform", name="a")
+          >>> b = cmds.createNode("transform", name="b")
+          >>> c = cmds.createNode("transform", name="c")
+          >>> cmds.select(a)
+          >>> gc = cmds.sets([a], name="grandchild")
+          >>> cc = cmds.sets([gc, b], name="child")
+          >>> parent = cmds.sets([cc, c], name="parent")
+          >>> mainset = encode(parent)
+          >>> sorted(mainset.flatten(), key=lambda n: n.name())
+          [<cmdx.DagNode : '|a'>, <cmdx.DagNode : '|b'>, <cmdx.DagNode : '|c'>]
+          >>> result = sorted([n.name() for n in mainset.flatten()])
+          >>> result in (
+          ...    ['a', 'b', 'c'],
+          ...    [u'a', u'b', u'c']
+          ... )
+          True
 
         """
 
@@ -2574,8 +2592,12 @@ class Plug(object):
         Example:
             >>> node = createNode("transform")
             >>> node["tx"] = 5
+            >>> node["translate"] + "X"
+            <cmdx.Plug : 5.0>
             >>> (node["translate"] + "X").read()
             5.0
+            >>> node["t"] + "x"
+            <cmdx.Plug : 5.0>
             >>> (node["t"] + "x").read()
             5.0
             >>> try:
@@ -2611,10 +2633,16 @@ class Plug(object):
             >>> node["myArray"].extend([2.0, 3.0])
             >>> node["myArray"] += 5.1
             >>> node["myArray"] += [1.1, 2.3, 999.0]
+            >>> node["myArray"][0]
+            <cmdx.Plug : 1.0>
             >>> node["myArray"][0].read()
             1.0
+            >>> node["myArray"][6]
+            <cmdx.Plug : 999.0>
             >>> node["myArray"][6].read()
             999.0
+            >>> node["myArray"][-1]
+            <cmdx.Plug : 999.0>
             >>> node["myArray"][-1].read()
             999.0
 
@@ -2818,6 +2846,8 @@ class Plug(object):
         Example:
             >>> node = createNode("transform")
             >>> node["translate"][0] = 5
+            >>> node["tx"]
+            <cmdx.Plug : 5.0>
             >>> node["tx"].read()
             5.0
 
@@ -3193,8 +3223,12 @@ class Plug(object):
             >>> node = createNode("transform")
             >>> node["myArray"] = Double(array=True)
             >>> node["myArray"].extend([1.0, 2.0, 3.0])
+            >>> node["myArray"][0]
+            <cmdx.Plug : 1.0>
             >>> node["myArray"][0].read()
             1.0
+            >>> node["myArray"][-1]
+            <cmdx.Plug : 3.0>
             >>> node["myArray"][-1].read()
             3.0
 
@@ -4121,6 +4155,8 @@ class Plug(object):
             True
             >>> b["ihi"].connection() == a
             True
+            >>> a["ihi"]
+            <cmdx.Plug : 2>
             >>> a["ihi"].read()
             2
             >>> b["arrayAttr"] = Long(array=True)
@@ -6370,8 +6406,9 @@ class _BaseModifier(object):
             >>> with DagModifier() as mod:
             ...     mod.connect(tm["sx"], tm["tx"])
             ...
-            >>> result = tm["tx"].connection().path()
-            >>> result in (
+            >>> tm["tx"].connection()
+            <cmdx.DagNode : '|myTransform'>
+            >>> tm["tx"].connection().path() in (
             ...    '|myTransform',
             ...   u'|myTransform'
             ... )
@@ -6383,8 +6420,9 @@ class _BaseModifier(object):
 
             # Connect without undo
             >>> tm["tx"] << tx["output"]
-            >>> result = tm["tx"].connection().name()
-            >>> result in (
+            >>> tm["tx"].connection()
+            <cmdx.AnimCurve : 'myAnimCurve'>
+            >>> tm["tx"].connection().name() in (
             ...    'myAnimCurve',
             ...   u'myAnimCurve'
             ... )
@@ -6473,16 +6511,18 @@ class _BaseModifier(object):
             ...     otherAttr = mod.addAttr(otherNode, Message("otherAttr"))
             ...     mod.connectAttr(newNode["newAttr"], otherNode, otherAttr)
             ...
-            >>> result = newNode["newAttr"].connection().path()
-            >>> result in (
+            >>> newNode["newAttr"].connection()
+            <cmdx.DagNode : '|otherNode'>
+            >>> newNode["newAttr"].connection().path() in (
             ...    '|otherNode',
             ...   u'|otherNode'
             ... )
             True
 
             >>> cmds.undo()
-            >>> result = newNode["newAttr"].connection().path()
-            >>> result in (
+            >>> newNode["newAttr"].connection()
+            <cmdx.DagNode : '|newNode'>
+            >>> newNode["newAttr"].connection().path() in (
             ...    '|newNode',
             ...   u'|newNode'
             ... )
@@ -6805,8 +6845,12 @@ class DagModifier(_BaseModifier):
         ...
         >>> getAttr(node1 + ".translateX")
         1.0
+        >>> node2["translate"][0]
+        <cmdx.Plug : 1.0>
         >>> node2["translate"][0].read()
         1.0
+        >>> node2["translate"][1]
+        <cmdx.Plug : 2.0>
         >>> node2["translate"][1].read()
         2.0
         >>> with DagModifier() as mod:
@@ -6815,8 +6859,12 @@ class DagModifier(_BaseModifier):
         ...     node1["translate"] = (5, 6, 7)
         ...     node1["translate"] >> node2["translate"]
         ...
+        >>> node2["translate"][0]
+        <cmdx.Plug : 5.0>
         >>> node2["translate"][0].read()
         5.0
+        >>> node2["translate"][1]
+        <cmdx.Plug : 6.0>
         >>> node2["translate"][1].read()
         6.0
 

--- a/cmdx.py
+++ b/cmdx.py
@@ -2674,12 +2674,16 @@ class Plug(object):
         return str(self.read())
 
     def __repr__(self):
+        cls_name = '{}.{}'.format(__name__, self.__class__.__name__)
+        if self._mplug.attribute().apiType() == om.MFn.kCompoundAttribute:
+            return '{}("{}", "{}")'.format(cls_name,
+                                           self.node().name(),
+                                           self.name())
         read_val = self.read()
         if isinstance(read_val, string_types):
             # Add surrounding single quotes, indicating the value is a string
             read_val = '"{}"'.format(read_val)
 
-        cls_name = '{}.{}'.format(__name__, self.__class__.__name__)
         return '{}("{}", "{}") == {}'.format(cls_name,
                                              self.node().name(),
                                              self.name(),
@@ -7818,7 +7822,7 @@ class _AbstractAttribute(dict):
     def __repr__(self):
         """Avoid repr depicting the full contents of this dict"""
         cls_name = '{}.{}'.format(__name__, self.__class__.__name__)
-        return "<{} : '{}'>".format(cls_name, self["name"])
+        return 'cmdx.{}("{}")'.format(cls_name, self["name"])
 
     def __new__(cls, *args, **kwargs):
         """Support for using name of assignment

--- a/cmdx.py
+++ b/cmdx.py
@@ -1524,13 +1524,21 @@ class DagNode(Node):
             >>> _new()
             >>> parent = createNode("transform", "parent")
             >>> child =  createNode("transform", "child", parent)
-            >>> (parent | "child").path()
-            '|parent|child'
+            >>> result = (parent | "child").path()
+            >>> result in (
+            ...    '|parent|child',
+            ...   u'|parent|child'
+            ... )
+            True
 
             # Stackable too
             >>> grand =  createNode("transform", "grand", child)
-            >>> (parent | "child" | "grand").path()
-            '|parent|child|grand'
+            >>> result = (parent | "child" | "grand").path()
+            >>> result in (
+            ...    '|parent|child|grand',
+            ...   u'|parent|child|grand'
+            ... )
+            True
 
         """
 
@@ -2303,8 +2311,12 @@ class ObjectSet(Node):
             >>> cc = cmds.sets([gc, b], name="child")
             >>> parent = cmds.sets([cc, c], name="parent")
             >>> mainset = encode(parent)
-            >>> sorted([n.path() for n in mainset.flatten()])
-            ['|a', '|b', '|c']
+            >>> result = sorted([n.path() for n in mainset.flatten()])
+            >>> result in (
+            ...    ['|a', '|b', '|c'],
+            ...    [u'|a', u'|b', u'|c']
+            ... )
+            True
 
         """
 
@@ -6358,16 +6370,25 @@ class _BaseModifier(object):
             >>> with DagModifier() as mod:
             ...     mod.connect(tm["sx"], tm["tx"])
             ...
-            >>> tm["tx"].connection().path()
-            '|myTransform'
+            >>> result = tm["tx"].connection().path()
+            >>> result in (
+            ...    '|myTransform',
+            ...   u'|myTransform'
+            ... )
+            True
+
             >>> cmds.undo()
             >>> tm["tx"].connection() is None
             True
 
             # Connect without undo
             >>> tm["tx"] << tx["output"]
-            >>> tm["tx"].connection().name()
-            'myAnimCurve'
+            >>> result = tm["tx"].connection().name()
+            >>> result in (
+            ...    'myAnimCurve',
+            ...   u'myAnimCurve'
+            ... )
+            True
 
             # Disconnect without undo
             >>> tm["tx"] // tx["output"]
@@ -6452,12 +6473,20 @@ class _BaseModifier(object):
             ...     otherAttr = mod.addAttr(otherNode, Message("otherAttr"))
             ...     mod.connectAttr(newNode["newAttr"], otherNode, otherAttr)
             ...
-            >>> newNode["newAttr"].connection().path()
-            '|otherNode'
+            >>> result = newNode["newAttr"].connection().path()
+            >>> result in (
+            ...    '|otherNode',
+            ...   u'|otherNode'
+            ... )
+            True
 
             >>> cmds.undo()
-            >>> newNode["newAttr"].connection().path()
-            '|newNode'
+            >>> result = newNode["newAttr"].connection().path()
+            >>> result in (
+            ...    '|newNode',
+            ...   u'|newNode'
+            ... )
+            True
 
         """
 

--- a/cmdx.py
+++ b/cmdx.py
@@ -2686,7 +2686,7 @@ class Plug(object):
                                       self.node().name(),
                                       self.name())
 
-        if not self.isCompound and not self.isArray:
+        if not all((self.isCompound, self.isArray)):
             # Delegate and include the value result from __str__
             read_result = str(self)
             attr = self._mplug.attribute()

--- a/cmdx.py
+++ b/cmdx.py
@@ -653,6 +653,13 @@ class Node(object):
             ... else:
             ...   assert False
             >>>
+            >>> node["myString"] = String()
+            >>> node["myString"]
+            cmdx.Plug("myNode", "myString") == ""
+            >>> node["myString"] = "Hello, world!"
+            >>> node["myString"]
+            cmdx.Plug("myNode", "myString") == "Hello, world!"
+            >>>
             >>> delete(node)
 
         """
@@ -2674,24 +2681,21 @@ class Plug(object):
         return str(self.read())
 
     def __repr__(self):
-        try:
-            # Delegate the value reading to __str__
-            read_result = str(self)
-            valid = True
-        except:
-            valid = False
-
         cls_name = '{}.{}'.format(__name__, self.__class__.__name__)
         msg = '{}("{}", "{}")'.format(cls_name,
                                       self.node().name(),
                                       self.name())
-        if valid:
-            try:
-                if self.typeClass() == String:
+
+        if not self.isCompound and not self.isArray:
+            # Delegate and include the value result from __str__
+            read_result = str(self)
+            attr = self._mplug.attribute()
+            typ = attr.apiType()
+            if typ == om.MFn.kTypedAttribute:
+                typ = om.MFnTypedAttribute(attr).attrType()
+                if typ == om.MFnData.kString:
                     # Add surrounding quotes, indicating it is a string
                     read_result = '"{}"'.format(read_result)
-            except TypeError:
-                pass
             msg += ' == {}'.format(read_result)
 
         return msg

--- a/tests.py
+++ b/tests.py
@@ -383,8 +383,9 @@ def test_nodeoperators():
 
     node = cmdx.createNode(cmdx.tTransform, name="myNode")
     assert_equals(node, "|myNode")
+    assert_equals(repr(node), "<cmdx.DagNode : '|myNode'>")
     assert_not_equals(node, "|NotEquals")
-    assert_equals(str(node), repr(node))
+    assert_not_equals(str(node), repr(node))
 
 
 @with_setup(new_scene)

--- a/tests.py
+++ b/tests.py
@@ -383,7 +383,7 @@ def test_nodeoperators():
 
     node = cmdx.createNode(cmdx.tTransform, name="myNode")
     assert_equals(node, "|myNode")
-    assert_equals(repr(node), "<cmdx.DagNode : '|myNode'>")
+    assert_equals(repr(node), 'cmdx.DagNode("myNode")')
     assert_not_equals(node, "|NotEquals")
     assert_not_equals(str(node), repr(node))
 


### PR DESCRIPTION
## Description of Changes
Expanding on #20 , this changes __repr__ to give a clear representation of what the object is, preventing the user from assuming it is a string. The goal, while not as forgiving, is to avoid unpredictable behavior by making the user having to explicitly request the name of a node via `.name()`, its path via `.path()`, and the value of one of its attributes via `.read()`.

**Note**: I opted to have `__str__` be different from `__repr__`, that way we still have the ability to `str(node)` and get the previous behavior, as seen by the changes done on **[tests.py](https://github.com/mottosso/cmdx/compare/master...chelloiaco:cmdx:repr-changes#diff-f455f302936271d755f6892d443786094d2607b505ff180ca817cb9eeabe1e5eL384-R388)**. I'm not certain if this would be confusing or unpredictable, but let me know.

## Testing done
As expected, I had to change the doctests to utilize `.name()`, `.path()` or `.read()` accordingly. After the changes, those pass without failures:
```
===Flaky Test Report===

test_createNode_performance passed 1 out of the required 3 times. Running test again until it passes 3 times.
test_createNode_performance passed 2 out of the required 3 times. Running test again until it passes 3 times.
test_createNode_performance passed 3 out of the required 3 times. Success!
test_rouge_mode passed 1 out of the required 3 times. Running test again until it passes 3 times.
test_rouge_mode passed 2 out of the required 3 times. Running test again until it passes 3 times.
test_rouge_mode passed 3 out of the required 3 times. Success!

===End Flaky Test Report===
----------------------------------------------------------------------
Ran 153 tests in 1.861s

OK
Skipping coveralls
```